### PR TITLE
CreateCAAuditReport, DescribeCAAuditReport, ImportCACert, RestoreCA, RevokeCert, UpdateCA

### DIFF
--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -100,6 +100,7 @@ acm-pca_UpdateCertificateAuthority:
 acm-pca_RootCAActivation:
   title: Create and activate a root CA programmatically
   title_abbrev: Create and activate a root CA programmatically
+  synopsis: shows how to create and activate a root CA using &AWS; Private CA API actions.
   category: Scenarios
   languages:
     Java:
@@ -118,6 +119,7 @@ acm-pca_RootCAActivation:
 acm-pca_SubordinateCAActivation:
   title: Create and activate a subordinate CA programmatically
   title_abbrev: Create and activate a subordinate CA programmatically
+  synopsis: shows how to create and activate a subordinate CA using &AWS; Private CA API actions.
   category: Scenarios
   languages:
     Java:
@@ -136,14 +138,10 @@ acm-pca_SubordinateCAActivation:
 acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
-  synopsis-list: | 
-     The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
-     operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
-
-     The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
-     For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
-
-     If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
+  synopsis-list: 
+    - The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). 
+    - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
+    - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios
   languages:
     Java:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -138,9 +138,7 @@ acm-pca_SubordinateCAActivation:
 acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
-  synopsis: shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). 
-  synopsis_list:	
-    - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
+  synopsis: shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios
   languages:
     Java:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -138,8 +138,8 @@ acm-pca_SubordinateCAActivation:
 acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
+  synopsis: shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). 
   synopsis-list: 
-    - The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). 
     - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
     - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -100,13 +100,6 @@ acm-pca_UpdateCertificateAuthority:
 acm-pca_RootCAActivation:
   title: Create and activate a root CA programmatically
   title_abbrev: Create and activate a root CA programmatically
-  synopsis: This Java sample shows how to activate a root CA using the following &AWS; Private CA API actions -  
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html"> CreateCertificateAuthority</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html"> GetCertificateAuthorityCsr</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html"> IssueCertificate</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html"> GetCertificate</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html"> ImportCertificateAuthorityCertificate.</ulink>
-  category: Scenarios
   languages:
     Java:
       versions:
@@ -124,13 +117,6 @@ acm-pca_RootCAActivation:
 acm-pca_SubordinateCAActivation:
   title: Create and activate a subordinate CA programmatically
   title_abbrev: Create and activate a subordinate CA programmatically
-  synopsis: This Java sample demonstrates how to activate a root CA by calling these &AWS; Private CA API actions in sequence - 
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCertificate.html"> GetCertificateAuthorityCertificate</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html"> CreateCertificateAuthority</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html"> GetCertificateAuthorityCsr</ulink>, 
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html"> IssueCertificate</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html"> GetCertificate</ulink>,
-     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html"> ImportCertificateAuthorityCertificate.</ulink>
   category: Scenarios
   languages:
     Java:
@@ -149,12 +135,12 @@ acm-pca_SubordinateCAActivation:
 acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
-  synopsis: |
+  synopsis-list: | 
      The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
-      operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
+     operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
 
      The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
-      For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
+     For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
 
      If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -169,6 +169,6 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
           excerpts:
             - description:
               snippet_tags:
-                - acmpca.java2.SubordinateCAActivation.main
+                - acmpca.CreatePrivateCertificateAuthorityAD.main
   services:
      acm-pca: {}

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -45,7 +45,7 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
   synopsis: |
-    The following Java sample shows how to use the CreateCertificateAuthority operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
+    use the CreateCertificateAuthority operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
 
     The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for more information and an &AWS; CLI example of an equivalent operation.
 

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -47,7 +47,7 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
   synopsis: |
     The following Java sample shows how to use the CreateCertificateAuthority operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
 
-    The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for more information and an AWS CLI example of an equivalent operation.
+    The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for more information and an &AWS; CLI example of an equivalent operation.
 
     If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -100,7 +100,7 @@ acm-pca_UpdateCertificateAuthority:
 acm-pca_RootCAActivation:
   title: Create and activate a root CA programmatically
   title_abbrev: Create and activate a root CA programmatically
-  synoposis-list:
+  synopsis_list:
     - This Java sample shows how to activate a root CA using the following AWS Private CA API actions
     - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
     - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
@@ -125,7 +125,7 @@ acm-pca_RootCAActivation:
 acm-pca_SubordinateCAActivation:
   title: Create and activate a subordinate CA programmatically
   title_abbrev: Create and activate a subordinate CA programmatically
-  synoposis-list:
+  synopsis_list:
     - This Java sample shows how to activate a subordinate CA using the following AWS Private CA API actions
     - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCertificate.html">GetCertificateAuthorityCertificate</ulink> 
     - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
@@ -151,13 +151,11 @@ acm-pca_SubordinateCAActivation:
 acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
-  synoposis-list:
+  synopsis_list:
     - The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
       operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
-
     - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
       For more information and an AWS CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> 
-
     - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios
   languages:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -100,13 +100,12 @@ acm-pca_UpdateCertificateAuthority:
 acm-pca_RootCAActivation:
   title: Create and activate a root CA programmatically
   title_abbrev: Create and activate a root CA programmatically
-  synopsis_list:
-    - This Java sample shows how to activate a root CA using the following &AWS; Private CA API actions.
-    - CreateCertificateAuthority
-    - GetCertificateAuthorityCsr
-    - IssueCertificate
-    - GetCertificate
-    - ImportCertificateAuthorityCertificate
+  synopsis: This Java sample shows how to activate a root CA using the following &AWS; Private CA API actions -  
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html"> CreateCertificateAuthority</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html"> GetCertificateAuthorityCsr</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html"> IssueCertificate</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html"> GetCertificate</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html"> ImportCertificateAuthorityCertificate.</ulink>
   category: Scenarios
   languages:
     Java:
@@ -125,14 +124,13 @@ acm-pca_RootCAActivation:
 acm-pca_SubordinateCAActivation:
   title: Create and activate a subordinate CA programmatically
   title_abbrev: Create and activate a subordinate CA programmatically
-  synopsis_list:
-    - This Java sample shows how to activate a subordinate CA using the following &AWS; Private CA API actions.
-    - GetCertificateAuthorityCertificate
-    - CreateCertificateAuthority
-    - GetCertificateAuthorityCsr
-    - IssueCertificate
-    - GetCertificate
-    - ImportCertificateAuthorityCertificate
+  synopsis: This Java sample demonstrates how to activate a root CA by calling these &AWS; Private CA API actions in sequence - 
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCertificate.html"> GetCertificateAuthorityCertificate</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html"> CreateCertificateAuthority</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html"> GetCertificateAuthorityCsr</ulink>, 
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html"> IssueCertificate</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html"> GetCertificate</ulink>,
+     <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html"> ImportCertificateAuthorityCertificate.</ulink>
   category: Scenarios
   languages:
     Java:
@@ -151,12 +149,14 @@ acm-pca_SubordinateCAActivation:
 acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
-  synopsis_list:
-    - The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
+  synopsis: |
+     The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
       operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
-    - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
+
+     The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
       For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
-    - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
+
+     If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios
   languages:
     Java:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -101,12 +101,12 @@ acm-pca_RootCAActivation:
   title: Create and activate a root CA programmatically
   title_abbrev: Create and activate a root CA programmatically
   synopsis_list:
-    - This Java sample shows how to activate a root CA using the following AWS Private CA API actions
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
+    - This Java sample shows how to activate a root CA using the following &AWS; Private CA API actions
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
   category: Scenarios
   languages:
     Java:
@@ -127,12 +127,12 @@ acm-pca_SubordinateCAActivation:
   title_abbrev: Create and activate a subordinate CA programmatically
   synopsis_list:
     - This Java sample shows how to activate a subordinate CA using the following AWS Private CA API actions
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCertificate.html">GetCertificateAuthorityCertificate</ulink> 
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
-    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCertificate.html">GetCertificateAuthorityCertificate</ulink> 
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
+    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
   category: Scenarios
   languages:
     Java:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -13,6 +13,20 @@ acm-pca_CreateCertificateAuthority:
   services:
      acm-pca: {CreateCertificateAuthority}
 
+acm-pca_CreateCertificateAuthorityAuditReport:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.CreateCertificateAuthorityAuditReport.main
+  services:
+     acm-pca: {CreateCertificateAuthorityAuditReport}
+
 acm-pca_CreatePermission:
   languages:
     Java:
@@ -26,6 +40,29 @@ acm-pca_CreatePermission:
                 - acmpca.java2.CreatePermission.main
   services:
      acm-pca: {CreatePermission}
+
+acm-pca_CreatePrivateCertificateAuthorityAD:
+  title: Using CreateCertificateAuthority to support Active Directory
+  title_abbrev: Using CreateCertificateAuthority to support Active Directory
+  synopsis: |
+    The following Java sample shows how to use the CreateCertificateAuthority operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
+
+    The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for more information and an AWS CLI example of an equivalent operation.
+
+    If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
+  category: Scenarios
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.CreatePrivateCertificateAuthorityAD.main
+  services:
+     acm-pca: {CreateCertificateAuthority}
 
 acm-pca_DeleteCertificateAuthority:
   languages:
@@ -83,6 +120,20 @@ acm-pca_DescribeCertificateAuthority:
   services:
      acm-pca: {DescribeCertificateAuthority}
 
+acm-pca_DescribeCertificateAuthorityAuditReport:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.DescribeCertificateAuthorityAuditReport.main
+  services:
+     acm-pca: {DescribeCertificateAuthorityAuditReport}
+
 acm-pca_GetCertificate:
   languages:
     Java:
@@ -138,6 +189,20 @@ acm-pca_GetPolicy:
                 - acmpca.java2.GetPolicy.main
   services:
      acm-pca: {GetPolicy}
+
+acm-pca_ImportCertificateAuthorityCertificate:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.ImportCertificateAuthorityCertificate.main
+  services:
+     acm-pca: {ImportCertificateAuthorityCertificate}
 
 acm-pca_IssueCertificate:
   languages:
@@ -209,6 +274,72 @@ acm-pca_PutPolicy:
   services:
      acm-pca: {PutPolicy}
 
+acm-pca_RestoreCertificateAuthority:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.RestoreCertificateAuthority.main
+  services:
+     acm-pca: {RestoreCertificateAuthority}
+
+acm-pca_RevokeCertificate:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.RevokeCertificate.main
+  services:
+     acm-pca: {RevokeCertificate}
+
+acm-pca_RootCAActivation:
+  title: Create and activate a root CA programmatically
+  title_abbrev: Create and activate a root CA programmatically
+  synopsis: create and activate a root CA using &AWS; Private CA API actions.
+  category: Scenarios
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.RootCAActivation.main
+  services:
+     acm-pca: {CreateCertificateAuthority, GetCertificateAuthorityCsr, 
+      IssueCertificate, GetCertificate, ImportCertificateAuthorityCertificate}
+
+acm-pca_SubordinateCAActivation:
+  title: Create and activate a subordinate CA programmatically
+  title_abbrev: Create and activate a subordinate CA programmatically
+  synopsis: create and activate a subordinate CA using &AWS; Private CA API actions.
+  category: Scenarios
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.SubordinateCAActivation.main
+  services:
+     acm-pca: {GetCertificateAuthorityCertificate, CreateCertificateAuthority, GetCertificateAuthorityCsr, 
+      IssueCertificate, GetCertificate, ImportCertificateAuthorityCertificate}
+
 acm-pca_TagCertificateAuthorities:
   languages:
     Java:
@@ -236,3 +367,17 @@ acm-pca_UntagCertificateAuthority:
                 - acmpca.java2.UntagCertificateAuthority.main
   services:
      acm-pca: {UntagCertificateAuthority}
+
+acm-pca_UpdateCertificateAuthority:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.UpdateCertificateAuthority.main
+  services:
+     acm-pca: {UpdateCertificateAuthority}

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -140,7 +140,6 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
   synopsis: shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). 
   synopsis_list:	
-    - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> . 
     - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios
   languages:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -100,6 +100,7 @@ acm-pca_UpdateCertificateAuthority:
 acm-pca_RootCAActivation:
   title: Create and activate a root CA programmatically
   title_abbrev: Create and activate a root CA programmatically
+  category: Scenarios
   languages:
     Java:
       versions:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -98,8 +98,8 @@ acm-pca_UpdateCertificateAuthority:
      acm-pca: {UpdateCertificateAuthority}
 
 acm-pca_RootCAActivation:
-  title: Create and activate a root CA programmatically.
-  title_abbrev: Create and activate a root CA programmatically.
+  title: Create and activate a root CA programmatically
+  title_abbrev: Create and activate a root CA programmatically
   synoposis-list:
     - This Java sample shows how to activate a root CA using the following AWS Private CA API actions
     - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
@@ -156,7 +156,7 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
       operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
 
     - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
-      For more information and an AWS CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login.</ulink> 
+      For more information and an AWS CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> 
 
     - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -96,3 +96,79 @@ acm-pca_UpdateCertificateAuthority:
                 - acmpca.java2.UpdateCertificateAuthority.main
   services:
      acm-pca: {UpdateCertificateAuthority}
+
+acm-pca_RootCAActivation:
+  title: Create and activate a root CA programmatically.
+  title_abbrev: Create and activate a root CA programmatically.
+  synoposis-list:
+    - This Java sample shows how to activate a root CA using the following AWS Private CA API actions
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
+  category: Scenarios
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.RootCAActivation.main
+  services:
+     acm-pca: {CreateCertificateAuthority, GetCertificateAuthorityCsr, 
+      IssueCertificate, GetCertificate, ImportCertificateAuthorityCertificate}
+
+acm-pca_SubordinateCAActivation:
+  title: Create and activate a subordinate CA programmatically
+  title_abbrev: Create and activate a subordinate CA programmatically
+  synoposis-list:
+    - This Java sample shows how to activate a subordinate CA using the following AWS Private CA API actions
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCertificate.html">GetCertificateAuthorityCertificate</ulink> 
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
+    - <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
+  category: Scenarios
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.SubordinateCAActivation.main
+  services:
+     acm-pca: {GetCertificateAuthorityCertificate, CreateCertificateAuthority, GetCertificateAuthorityCsr, 
+      IssueCertificate, GetCertificate, ImportCertificateAuthorityCertificate}
+
+acm-pca_CreatePrivateCertificateAuthorityAD:
+  title: Using CreateCertificateAuthority to support Active Directory
+  title_abbrev: Using CreateCertificateAuthority to support Active Directory
+  synoposis-list:
+    - The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
+      operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
+
+    - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
+      For more information and an AWS CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login.</ulink> 
+
+    - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
+  category: Scenarios
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.SubordinateCAActivation.main
+  services:
+     acm-pca: {}

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -101,12 +101,12 @@ acm-pca_RootCAActivation:
   title: Create and activate a root CA programmatically
   title_abbrev: Create and activate a root CA programmatically
   synopsis_list:
-    - This Java sample shows how to activate a root CA using the following &AWS; Private CA API actions
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
+    - This Java sample shows how to activate a root CA using the following &AWS; Private CA API actions.
+    - CreateCertificateAuthority
+    - GetCertificateAuthorityCsr
+    - IssueCertificate
+    - GetCertificate
+    - ImportCertificateAuthorityCertificate
   category: Scenarios
   languages:
     Java:
@@ -126,13 +126,13 @@ acm-pca_SubordinateCAActivation:
   title: Create and activate a subordinate CA programmatically
   title_abbrev: Create and activate a subordinate CA programmatically
   synopsis_list:
-    - This Java sample shows how to activate a subordinate CA using the following AWS Private CA API actions
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCertificate.html">GetCertificateAuthorityCertificate</ulink> 
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html">GetCertificateAuthorityCsr</ulink>
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_IssueCertificate.html">IssueCertificate</ulink>
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html">GetCertificate</ulink>
-    - Use <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html">ImportCertificateAuthorityCertificate</ulink>
+    - This Java sample shows how to activate a subordinate CA using the following &AWS; Private CA API actions.
+    - GetCertificateAuthorityCertificate
+    - CreateCertificateAuthority
+    - GetCertificateAuthorityCsr
+    - IssueCertificate
+    - GetCertificate
+    - ImportCertificateAuthorityCertificate
   category: Scenarios
   languages:
     Java:
@@ -155,7 +155,7 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
     - The following Java sample shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> 
       operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
     - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).
-      For more information and an AWS CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> 
+      For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
     - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios
   languages:
@@ -169,4 +169,4 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
               snippet_tags:
                 - acmpca.CreatePrivateCertificateAuthorityAD.main
   services:
-     acm-pca: {}
+     acm-pca: {CreateCertificateAuthority}

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -139,7 +139,7 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
   title: Using CreateCertificateAuthority to support Active Directory
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
   synopsis: shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). 
-  synopsis-list: 
+  synopsis_list:	
     - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
     - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -13,3 +13,86 @@ acm-pca_CreateCertificateAuthority:
   services:
      acm-pca: {CreateCertificateAuthority}
 
+acm-pca_CreateCertificateAuthorityAuditReport:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.CreateCertificateAuthorityAuditReport.main
+  services:
+     acm-pca: {CreateCertificateAuthorityAuditReport}
+
+acm-pca_DescribeCertificateAuthorityAuditReport:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.DescribeCertificateAuthorityAuditReport.main
+  services:
+     acm-pca: {DescribeCertificateAuthorityAuditReport}
+
+acm-pca_ImportCertificateAuthorityCertificate:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.ImportCertificateAuthorityCertificate.main
+  services:
+     acm-pca: {ImportCertificateAuthorityCertificate}
+
+acm-pca_RestoreCertificateAuthority:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.RestoreCertificateAuthority.main
+  services:
+     acm-pca: {RestoreCertificateAuthority}
+
+acm-pca_RevokeCertificate:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.RevokeCertificate.main
+  services:
+     acm-pca: {RevokeCertificate}
+
+acm-pca_UpdateCertificateAuthority:
+  languages:
+    Java:
+      versions:
+        - sdk_version: 2
+          github: javav2/example_code/acmpca
+          sdkguide:
+          excerpts:
+            - description:
+              snippet_tags:
+                - acmpca.java2.UpdateCertificateAuthority.main
+  services:
+     acm-pca: {UpdateCertificateAuthority}

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -140,7 +140,7 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
   title_abbrev: Using CreateCertificateAuthority to support Active Directory
   synopsis: shows how to use the <ulink url="https://docs.aws.amazon.com/privateca/latest/APIReference/API_CreateCertificateAuthority.html">CreateCertificateAuthority</ulink> operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD). 
   synopsis_list:	
-    - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink>. 
+    - The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs).For more information and an &AWS; CLI example of an equivalent operation, see <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> . 
     - If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
   category: Scenarios
   languages:

--- a/.doc_gen/metadata/acmpca_metadata.yaml
+++ b/.doc_gen/metadata/acmpca_metadata.yaml
@@ -47,9 +47,9 @@ acm-pca_CreatePrivateCertificateAuthorityAD:
   synopsis: |
     use the CreateCertificateAuthority operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
 
-    The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for more information and an &AWS; CLI example of an equivalent operation.
+    The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for an &AWS; CLI example of an equivalent operation and for more information.
 
-    If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
+    If successful, this function returns the Amazon Resource Name (ARN) of the CA.  
   category: Scenarios
   languages:
     Java:

--- a/javav2/example_code/acmpca/README.md
+++ b/javav2/example_code/acmpca/README.md
@@ -1,79 +1,150 @@
-# AWS Private Certificate Authority code examples for the SDK Java 2.x
+# AWS Private CA code examples for the SDK for Java 2.x
 
-## Available examples
+## Overview
 
-**Single Actions**
+Shows how to use the AWS SDK for Java 2.x to work with AWS Private Certificate Authority.
 
-Code samples that show you how to call individual service functions.
+<!--custom.overview.start-->
+<!--custom.overview.end-->
 
-* **CreateCertificateAuthority** 
-* **CreateCertificateAuthorityAuditReport** 
-* **CreatePermission** 
-* **DeleteCertificateAuthority** 
-* **DeletePermission** 
-* **DeletePolicy** 
-* **DescribeCertificateAuthority** 
-* **DescribeCertificateAuthorityAuditReport** 
-* **GetCertificate** 
-* **GetCertificateAuthorityCertificate** 
-* **GetCertificateAuthorityCsr** 
-* **GetPolicy** 
-* **ImportCertificateAuthorityCertificate** 
-* **IssueCertificate** 
-* **ListCertificateAuthorities** 
-* **ListPermissions** 
-* **ListTags** 
-* **PutPolicy** 
-* **RestoreCertificateAuthority** 
-* **RevokeCertificate** 
-* **TagCertificateAuthorities** 
-* **UntagCertificateAuthority** 
-* **UpdateCertificateAuthority** 
+_AWS Private CA _
 
-**Scenarios**
+## ⚠ Important
 
-Code samples that demonstrate a specific task.
+* Running this code might result in charges to your AWS account. For more details, see [AWS Pricing](https://aws.amazon.com/pricing/) and [Free Tier](https://aws.amazon.com/free/).
+* Running the tests might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the minimum permissions required to perform the task. For more information, see [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
-* **Create and Activate a root CA programmatically** 
-* **Create and activate a subordinate CA programmatically** 
-* **Using CertificateAuthority to support Active Directory** 
+<!--custom.important.start-->
+<!--custom.important.end-->
 
-## Running the AWS Private Certificate Authority Java files
+## Code examples
 
-**IMPORTANT**
+### Prerequisites
 
-The Java code examples perform AWS operations for the account and AWS Region for which you've specified credentials, and you may incur AWS service charges by running them. See the [AWS Pricing page](https://aws.amazon.com/pricing/) for details about the charges you can expect for a given service and operation.
+For prerequisites, see the [README](../../README.md#Prerequisites) in the `javav2` folder.
 
-Some of these examples perform *destructive* operations on AWS resources, such as creating a certificate authority. **Be very careful** when running an operation that creates, modifies, or deletes AWS resources in your account. It's best to create separate test-only resources when experimenting with these examples.
 
-## Prerequisites
+<!--custom.prerequisites.start-->
+<!--custom.prerequisites.end-->
 
-You must have an AWS account, and have your default credentials and AWS Region configured as described in the [AWS Tools and SDKs Shared Configuration and Credentials Reference Guide](https://docs.aws.amazon.com/credref/latest/refdoc/creds-config-files.html).
+### Single actions
 
-For general prerequisites, see the [README](../../README.md#Prerequisites) in the `javav2` folder.
+Code excerpts that show you how to call individual service functions.
 
-## Running the example
+- [CreateCertificateAuthority](src/main/java/com/example/acmpca/CreateCertificateAuthority.java#L22)
+- [CreateCertificateAuthorityAuditReport](src/main/java/com/example/acmpca/CreateCertificateAuthorityAuditReport.java#L12)
+- [CreatePermission](src/main/java/com/example/acmpca/CreatePermission.java#L14)
+- [DeleteCertificateAuthority](src/main/java/com/example/acmpca/DeleteCertificateAuthority.java#L11)
+- [DeletePermission](src/main/java/com/example/acmpca/DeletePermission.java#L11)
+- [DeletePolicy](src/main/java/com/example/acmpca/DeletePolicy.java#L11)
+- [DescribeCertificateAuthority](src/main/java/com/example/acmpca/DescribeCertificateAuthority.java#L13)
+- [DescribeCertificateAuthorityAuditReport](src/main/java/com/example/acmpca/DescribeCertificateAuthorityAuditReport.java#L14)
+- [GetCertificate](src/main/java/com/example/acmpca/GetCertificate.java#L13)
+- [GetCertificateAuthorityCertificate](src/main/java/com/example/acmpca/GetCertificateAuthorityCertificate.java#L12)
+- [GetCertificateAuthorityCsr](src/main/java/com/example/acmpca/GetCertificateAuthorityCsr.java#L13)
+- [GetPolicy](src/main/java/com/example/acmpca/GetPolicy.java#L12)
+- [ImportCertificateAuthorityCertificate](src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java#L16)
+- [IssueCertificate](src/main/java/com/example/acmpca/IssueCertificate.java#L19)
+- [ListCertificateAuthorities](src/main/java/com/example/acmpca/ListCertificateAuthorities.java#L13)
+- [ListPermissions](src/main/java/com/example/acmpca/ListPermissions.java#L13)
+- [ListTags](src/main/java/com/example/acmpca/ListTags.java#L12)
+- [PutPolicy](src/main/java/com/example/acmpca/PutPolicy.java#L13)
+- [RestoreCertificateAuthority](src/main/java/com/example/acmpca/RestoreCertificateAuthority.java#L11)
+- [RevokeCertificate](src/main/java/com/example/acmpca/RevokeCertificate.java#L13)
+- [TagCertificateAuthorities](src/main/java/com/example/acmpca/TagCertificateAuthorities.java#L14)
+- [UntagCertificateAuthority](src/main/java/com/example/acmpca/UntagCertificateAuthority.java#L14)
+- [UpdateCertificateAuthority](src/main/java/com/example/acmpca/UpdateCertificateAuthority.java#L14)
 
-To run the code examples, see the usage instructions in the comments of the example file. 
+### Scenarios
 
-The example requires parameters for the AWS region and an S3 bucket name for CRL revocation to run the CreateCertificateAuthority code sample.
+Code examples that show you how to accomplish a specific task by calling multiple
+functions within the same service.
 
-For example:
+- [Create and activate a root CA programmatically](src/main/java/com/example/acmpca/scenarios/RootCAActivation.java)
+- [Create and activate a subordinate CA programmatically](src/main/java/com/example/acmpca/scenarios/SubordinateCAActivation.java)
+- [Using CreateCertificateAuthority to support Active Directory](src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java)
 
-mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-crl-bucket"
 
-## Tests
+<!--custom.examples.start-->
+<!--custom.examples.end-->
 
-You can test the Java code examples for AWS Private Certificate Authority by running the test file named **PCATests**.
+## Run the examples
+
+### Instructions
+
+
+<!--custom.instructions.start-->
+<!--custom.instructions.end-->
+
+
+
+#### Create and activate a root CA programmatically
+
+This example shows you how to create and activate a root CA using AWS Private CA API actions.
+
+
+<!--custom.scenario_prereqs.acm-pca_RootCAActivation.start-->
+<!--custom.scenario_prereqs.acm-pca_RootCAActivation.end-->
+
+
+<!--custom.scenarios.acm-pca_RootCAActivation.start-->
+<!--custom.scenarios.acm-pca_RootCAActivation.end-->
+
+#### Create and activate a subordinate CA programmatically
+
+This example shows you how to create and activate a subordinate CA using AWS Private CA API actions.
+
+
+<!--custom.scenario_prereqs.acm-pca_SubordinateCAActivation.start-->
+<!--custom.scenario_prereqs.acm-pca_SubordinateCAActivation.end-->
+
+
+<!--custom.scenarios.acm-pca_SubordinateCAActivation.start-->
+<!--custom.scenarios.acm-pca_SubordinateCAActivation.end-->
+
+#### Using CreateCertificateAuthority to support Active Directory
+
+This example shows you how to use the CreateCertificateAuthority operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
+
+The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for more information and an AWS CLI example of an equivalent operation.
+
+If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
+
+
+
+<!--custom.scenario_prereqs.acm-pca_CreatePrivateCertificateAuthorityAD.start-->
+<!--custom.scenario_prereqs.acm-pca_CreatePrivateCertificateAuthorityAD.end-->
+
+
+<!--custom.scenarios.acm-pca_CreatePrivateCertificateAuthorityAD.start-->
+<!--custom.scenarios.acm-pca_CreatePrivateCertificateAuthorityAD.end-->
+
+### Tests
+
+⚠ Running tests might result in charges to your AWS account.
+
 
 To find instructions for running these tests, see the [README](../../README.md#Tests)
 in the `javav2` folder.
 
+
+
+<!--custom.tests.start-->
+<!--custom.tests.end-->
+
 ## Additional resources
 
-* [AWS Private Certificate Authority Developer Guide](https://docs.aws.amazon.com/privateca/latest/userguide/PcaWelcome.html)
-* [AWS SDK for Java v2 Developer Guide](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html)
+- [AWS Private CA User Guide](https://docs.aws.amazon.com/privateca/latest/userguide/PcaWelcome.html)
+- [AWS Private CA API Reference](https://docs.aws.amazon.com/privateca/latest/APIReference/Welcome.html)
+- [SDK for Java 2.x AWS Private CA reference](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/acm-pca/package-summary.html)
+
+<!--custom.resources.start-->
+<!--custom.resources.end-->
 
 ---
+
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
 SPDX-License-Identifier: Apache-2.0

--- a/javav2/example_code/acmpca/README.md
+++ b/javav2/example_code/acmpca/README.md
@@ -7,8 +7,6 @@ Shows how to use the AWS SDK for Java 2.x to work with AWS Private Certificate A
 <!--custom.overview.start-->
 <!--custom.overview.end-->
 
-_AWS Private CA _
-
 ## ⚠ Important
 
 * Running this code might result in charges to your AWS account. For more details, see [AWS Pricing](https://aws.amazon.com/pricing/) and [Free Tier](https://aws.amazon.com/free/).
@@ -76,63 +74,27 @@ functions within the same service.
 
 
 <!--custom.instructions.start-->
+To run the code examples, see the usage instructions in the comments of the example file. 
+
+The example requires parameters for the AWS region and an S3 bucket name for CRL revocation to run the CreateCertificateAuthority code sample.
+
+For example:
+
+mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-crl-bucket"
 <!--custom.instructions.end-->
 
-
-
-#### Create and activate a root CA programmatically
-
-This example shows you how to create and activate a root CA using AWS Private CA API actions.
-
-
-<!--custom.scenario_prereqs.acm-pca_RootCAActivation.start-->
-<!--custom.scenario_prereqs.acm-pca_RootCAActivation.end-->
-
-
-<!--custom.scenarios.acm-pca_RootCAActivation.start-->
-<!--custom.scenarios.acm-pca_RootCAActivation.end-->
-
-#### Create and activate a subordinate CA programmatically
-
-This example shows you how to create and activate a subordinate CA using AWS Private CA API actions.
-
-
-<!--custom.scenario_prereqs.acm-pca_SubordinateCAActivation.start-->
-<!--custom.scenario_prereqs.acm-pca_SubordinateCAActivation.end-->
-
-
-<!--custom.scenarios.acm-pca_SubordinateCAActivation.start-->
-<!--custom.scenarios.acm-pca_SubordinateCAActivation.end-->
-
-#### Using CreateCertificateAuthority to support Active Directory
-
-This example shows you how to use the CreateCertificateAuthority operation to create a CA that can be installed in the Enterprise NTAuth store of Microsoft Active Directory (AD).
-
-The operation creates a private root certificate authority (CA) using custom object identifiers (OIDs). See <ulink url="https://docs.aws.amazon.com/privateca/latest/userguide/create-CA.html#example_5">Create a CA for Active Directory login</ulink> for more information and an AWS CLI example of an equivalent operation.
-
-If successful, this function returns the Amazon Resource Name (ARN) of the CA. 
-
-
-
-<!--custom.scenario_prereqs.acm-pca_CreatePrivateCertificateAuthorityAD.start-->
-<!--custom.scenario_prereqs.acm-pca_CreatePrivateCertificateAuthorityAD.end-->
-
-
-<!--custom.scenarios.acm-pca_CreatePrivateCertificateAuthorityAD.start-->
-<!--custom.scenarios.acm-pca_CreatePrivateCertificateAuthorityAD.end-->
 
 ### Tests
 
 ⚠ Running tests might result in charges to your AWS account.
 
+<!--custom.tests.start-->
+You can test the Java code examples for AWS Private Certificate Authority by running the test file named **PCATests**.
+<!--custom.tests.end-->
 
 To find instructions for running these tests, see the [README](../../README.md#Tests)
 in the `javav2` folder.
 
-
-
-<!--custom.tests.start-->
-<!--custom.tests.end-->
 
 ## Additional resources
 

--- a/javav2/example_code/acmpca/README.md
+++ b/javav2/example_code/acmpca/README.md
@@ -28,7 +28,7 @@ Code samples that show you how to call individual service functions.
 * **TagCertificateAuthority** 
 * **UntagCertificateAuthority** 
 
-**IMPORTANT**
+**Sceanrios**
 
 Code samples that demonstrate a specific task.
 
@@ -58,7 +58,7 @@ The example requires parameters for the AWS region and an S3 bucket name for CRL
 
 For example:
 
-mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-s3-bucket"
+mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-crl-bucket"
 
 ## Tests
 
@@ -66,29 +66,6 @@ You can test the Java code examples for AWS Private Certificate Authority by run
 
 To find instructions for running these tests, see the [README](../../README.md#Tests)
 in the `javav2` folder.
-
-You will see the output from the JUnit tests, as shown here:
-
-     [INFO] -------------------------------------------------------
-     [INFO]  T E S T S
-     [INFO] -------------------------------------------------------
-     [INFO] Running PCATests
-     [main] INFO PCATests - Test 1 passed
-     [main] INFO PCATests - Test 2 passed
-
-      ....
-     [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
-     [INFO] 
-     [INFO] Results:
-     [INFO] 
-     [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
-     [INFO] 
-     [INFO] ------------------------------------------------------------------------
-     [INFO] BUILD SUCCESS
-     [INFO] ------------------------------------------------------------------------
-     [INFO] Total time:  3.103 s
-     [INFO] Finished at: 2025-07-29T15:09:08Z
-     [INFO] ------------------------------------------------------------------------
 
 ## Additional resources
 

--- a/javav2/example_code/acmpca/README.md
+++ b/javav2/example_code/acmpca/README.md
@@ -2,7 +2,39 @@
 
 ## Available examples
 
-* **CreateCertificateAuthority** - Create a new private certificate authority
+**Single Actions**
+
+Code samples that show you how to call individual service functions.
+
+* **CreateCertificateAuthority** 
+* **CreateCertificateAuthorityAuditReport** 
+* **CreatePermissions** 
+* **DeleteCertificateAuthority** 
+* **DeletePermission** 
+* **DeletePolicy** 
+* **DescribeCertificateAuthority** 
+* **DescribeCertificateAuthorityAuditReport** 
+* **GetCertificate** 
+* **GetCertificateAuthorityCertificate** 
+* **GetCertificateAuthorityCsr** 
+* **GetPolicy** 
+* **ImportCertificateAuthorityCertificate** 
+* **IssueCertificate** 
+* **ListCertificateAuthorites** 
+* **ListPermissions** 
+* **ListTags** 
+* **PutPolicy** 
+* **RestoreCertificateAuthority** 
+* **TagCertificateAuthority** 
+* **UntagCertificateAuthority** 
+
+**IMPORTANT**
+
+Code samples that demonstrate a specific task.
+
+* **Create and Activate a root CA programmatically** 
+* **Create and activate a subordinate CA programmatically** 
+* **Using CertificateAuthority to support Active Directory** 
 
 ## Running the AWS Private Certificate Authority Java files
 
@@ -20,11 +52,13 @@ For general prerequisites, see the [README](../../README.md#Prerequisites) in th
 
 ## Running the example
 
-To run the CreateCertificateAuthority example, see the usage instructions in the comments of the example file. The example requires parameters for the AWS region and an S3 bucket name for CRL revocation.
+To run the code examples, see the usage instructions in the comments of the example file. 
+
+The example requires parameters for the AWS region and an S3 bucket name for CRL revocation to run the CreateCertificateAuthority code sample.
 
 For example:
 
-mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-crl-bucket"
+mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-s3-bucket"
 
 ## Tests
 
@@ -33,12 +67,33 @@ You can test the Java code examples for AWS Private Certificate Authority by run
 To find instructions for running these tests, see the [README](../../README.md#Tests)
 in the `javav2` folder.
 
+You will see the output from the JUnit tests, as shown here:
+
+     [INFO] -------------------------------------------------------
+     [INFO]  T E S T S
+     [INFO] -------------------------------------------------------
+     [INFO] Running PCATests
+     [main] INFO PCATests - Test 1 passed
+     [main] INFO PCATests - Test 2 passed
+
+      ....
+     [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+     [INFO] 
+     [INFO] Results:
+     [INFO] 
+     [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+     [INFO] 
+     [INFO] ------------------------------------------------------------------------
+     [INFO] BUILD SUCCESS
+     [INFO] ------------------------------------------------------------------------
+     [INFO] Total time:  3.103 s
+     [INFO] Finished at: 2025-07-29T15:09:08Z
+     [INFO] ------------------------------------------------------------------------
 
 ## Additional resources
 
 * [AWS Private Certificate Authority Developer Guide](https://docs.aws.amazon.com/privateca/latest/userguide/PcaWelcome.html)
 * [AWS SDK for Java v2 Developer Guide](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html)
-
 
 ---
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/javav2/example_code/acmpca/README.md
+++ b/javav2/example_code/acmpca/README.md
@@ -76,11 +76,11 @@ functions within the same service.
 <!--custom.instructions.start-->
 To run the code examples, see the usage instructions in the comments of the example file. 
 
-The example requires parameters for the AWS region and an S3 bucket name for CRL revocation to run the CreateCertificateAuthority code sample.
+For Example:
 
-For example:
+This example requires parameters for the AWS region and an S3 bucket name for CRL revocation to run the CreateCertificateAuthority code sample.
 
-mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-crl-bucket"
+**mvn exec:java -Dexec.mainClass="com.example.acmpca.CreateCertificateAuthority" -Dexec.args="us-east-1 my-crl-bucket"**
 <!--custom.instructions.end-->
 
 

--- a/javav2/example_code/acmpca/README.md
+++ b/javav2/example_code/acmpca/README.md
@@ -8,7 +8,7 @@ Code samples that show you how to call individual service functions.
 
 * **CreateCertificateAuthority** 
 * **CreateCertificateAuthorityAuditReport** 
-* **CreatePermissions** 
+* **CreatePermission** 
 * **DeleteCertificateAuthority** 
 * **DeletePermission** 
 * **DeletePolicy** 
@@ -20,15 +20,17 @@ Code samples that show you how to call individual service functions.
 * **GetPolicy** 
 * **ImportCertificateAuthorityCertificate** 
 * **IssueCertificate** 
-* **ListCertificateAuthorites** 
+* **ListCertificateAuthorities** 
 * **ListPermissions** 
 * **ListTags** 
 * **PutPolicy** 
 * **RestoreCertificateAuthority** 
-* **TagCertificateAuthority** 
+* **RevokeCertificate** 
+* **TagCertificateAuthorities** 
 * **UntagCertificateAuthority** 
+* **UpdateCertificateAuthority** 
 
-**Sceanrios**
+**Scenarios**
 
 Code samples that demonstrate a specific task.
 

--- a/javav2/example_code/acmpca/pom.xml
+++ b/javav2/example_code/acmpca/pom.xml
@@ -74,5 +74,11 @@
       <version>5.8.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/javav2/example_code/acmpca/pom.xml
+++ b/javav2/example_code/acmpca/pom.xml
@@ -10,6 +10,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
+        <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <maven.compiler.target>17</maven.compiler.target>

--- a/javav2/example_code/acmpca/pom.xml
+++ b/javav2/example_code/acmpca/pom.xml
@@ -57,20 +57,9 @@
       <artifactId>aws-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.78.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.78.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>1.18.34</version>
-      <scope>provided</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.9</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -88,12 +77,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>5.8.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/javav2/example_code/acmpca/pom.xml
+++ b/javav2/example_code/acmpca/pom.xml
@@ -57,6 +57,22 @@
       <artifactId>aws-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.78.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.78.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.34</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.11.4</version>

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/CreateCertificateAuthorityAuditReport.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/CreateCertificateAuthorityAuditReport.java
@@ -53,13 +53,13 @@ public class CreateCertificateAuthorityAuditReport {
 
     try {
       CreateCertificateAuthorityAuditReportResponse result = 
-      client.createCertificateAuthorityAuditReport(req);
+          client.createCertificateAuthorityAuditReport(req);
 
-      String ID = result.auditReportId();
-      String S3Key = result.s3Key();
+      String id = result.auditReportId();
+      String s3Key = result.s3Key();
 
-      System.out.println("Certificate Authority Audit Report ID:" + ID);
-      System.out.println("S3 Object Key:" + S3Key);
+      System.out.println("Certificate Authority Audit Report ID: " + id);
+      System.out.println("S3 Object Key: " + s3Key);
     } catch (AcmPcaException ex) {
       System.err.println(ex.awsErrorDetails().errorMessage());
     } 

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/CreateCertificateAuthorityAuditReport.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/CreateCertificateAuthorityAuditReport.java
@@ -58,8 +58,8 @@ public class CreateCertificateAuthorityAuditReport {
       String ID = result.auditReportId();
       String S3Key = result.s3Key();
 
-      System.out.println(ID);
-      System.out.println(S3Key);
+      System.out.println("Certificate Authority Audit Report ID:" + ID);
+      System.out.println("S3 Object Key:" + S3Key);
     } catch (AcmPcaException ex) {
       System.err.println(ex.awsErrorDetails().errorMessage());
     } 

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/CreateCertificateAuthorityAuditReport.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/CreateCertificateAuthorityAuditReport.java
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityAuditReportRequest;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityAuditReportResponse;
+
+// snippet-start:[acmpca.java2.CreateCertificateAuthorityAuditReport.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class CreateCertificateAuthorityAuditReport {
+
+   public static void main(String[] args) throws Exception {
+
+    final String usage =
+        """
+            Usage: <region> <s3Bucket> <caArn>
+
+            Where:
+                region - The AWS region (e.g., us-east-1)
+                s3Bucket - The S3 bucket name for your report
+                caArn - The ARN of the certificate authority
+            """;
+
+    if (args.length != 3) {
+      System.out.println(usage);
+      return;
+    }
+
+    String region = args[0];
+    String s3Bucket = args[1];
+    String caArn = args[2];
+
+    // Create a client that you can use to make requests.
+    AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+
+    // Create a request object and specify the audit response format.
+    CreateCertificateAuthorityAuditReportRequest req =
+        CreateCertificateAuthorityAuditReportRequest.builder()
+            .certificateAuthorityArn(caArn)
+            .s3BucketName(s3Bucket)
+            .auditReportResponseFormat("JSON")
+            .build();
+
+    try {
+      CreateCertificateAuthorityAuditReportResponse result = 
+      client.createCertificateAuthorityAuditReport(req);
+
+      String ID = result.auditReportId();
+      String S3Key = result.s3Key();
+
+      System.out.println(ID);
+      System.out.println(S3Key);
+    } catch (AcmPcaException ex) {
+      System.err.println(ex.awsErrorDetails().errorMessage());
+    } 
+   }
+}
+// snippet-end:[acmpca.java2.CreateCertificateAuthorityAuditReport.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/DescribeCertificateAuthorityAuditReport.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/DescribeCertificateAuthorityAuditReport.java
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import java.time.Instant;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.DescribeCertificateAuthorityAuditReportRequest;
+import software.amazon.awssdk.services.acmpca.model.DescribeCertificateAuthorityAuditReportResponse;
+import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
+
+// snippet-start:[acmpca.java2.DescribeCertificateAuthorityAuditReport.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class DescribeCertificateAuthorityAuditReport {
+
+   public static void main(String[] args) throws Exception {
+
+    final String usage =
+        """
+            Usage: <region> <caArn> <reportId>
+
+            Where:
+                region - The AWS region (e.g. us-east-1)
+                caArn - The ARN of the certificate authority
+                reportId - The ID of the audit report (e.g. "11111111-2222-3333-4444-555555555555")
+            """;
+
+    if (args.length != 3) {
+      System.out.println(usage);
+      return;
+    }
+
+    String region = args[0];
+    String caArn = args[1];
+    String reportId = args[2];
+
+    // Create a client that you can use to make requests.
+    AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+
+    // Create a request object.
+    DescribeCertificateAuthorityAuditReportRequest req =
+        DescribeCertificateAuthorityAuditReportRequest.builder()
+            .certificateAuthorityArn(caArn)
+            .auditReportId(reportId)
+            .build();
+
+    // Create waiter to wait on successful creation of the audit report file.
+    try (AcmPcaWaiter waiter = client.waiter()){
+      waiter.waitUntilAuditReportCreated(
+         b -> b.certificateAuthorityArn(caArn).auditReportId(reportId).build());
+    } catch (AcmPcaException ex) {
+      System.err.println(ex.awsErrorDetails().errorMessage());
+    }
+
+    try {
+      DescribeCertificateAuthorityAuditReportResponse result = 
+      client.describeCertificateAuthorityAuditReport(req);
+
+      String status = result.auditReportStatusAsString();
+      String s3Bucket = result.s3BucketName();
+      String s3Key = result.s3Key();
+      Instant createdAt = result.createdAt(); 
+
+      System.out.println(status);
+      System.out.println(s3Bucket);
+      System.out.println(s3Key);
+      System.out.println(createdAt);
+
+    } catch (AcmPcaException ex){
+      System.err.println(ex.awsErrorDetails().errorMessage());
+    }
+  }
+}
+// snippet-end:[acmpca.java2.DescribeCertificateAuthorityAuditReport.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/DescribeCertificateAuthorityAuditReport.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/DescribeCertificateAuthorityAuditReport.java
@@ -62,7 +62,7 @@ public class DescribeCertificateAuthorityAuditReport {
 
     try {
       DescribeCertificateAuthorityAuditReportResponse result = 
-      client.describeCertificateAuthorityAuditReport(req);
+         client.describeCertificateAuthorityAuditReport(req);
 
       String status = result.auditReportStatusAsString();
       String s3Bucket = result.s3BucketName();

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/DescribeCertificateAuthorityAuditReport.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/DescribeCertificateAuthorityAuditReport.java
@@ -69,10 +69,10 @@ public class DescribeCertificateAuthorityAuditReport {
       String s3Key = result.s3Key();
       Instant createdAt = result.createdAt(); 
 
-      System.out.println(status);
-      System.out.println(s3Bucket);
-      System.out.println(s3Key);
-      System.out.println(createdAt);
+      System.out.println("AuditReportStatus: " + status);
+      System.out.println("S3BucketName: " + s3Bucket);
+      System.out.println("s3Key: " + s3Key);
+      System.out.println("Audit Report was created on: " + createdAt);
 
     } catch (AcmPcaException ex){
       System.err.println(ex.awsErrorDetails().errorMessage());

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.ImportCertificateAuthorityCertificateRequest;
+
+// snippet-start:[acmpca.java2.ImportCertificateAuthorityCertificate.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class ImportCertificateAuthorityCertificate {
+
+  public static void main(String[] args) throws Exception {
+
+    final String usage =
+        """
+            Usage: <region> <caArn>
+
+            Where:
+                region - The AWS region (e.g. us-east-1)
+                caArn - The ARN of the certificate authority
+            """;
+
+    if (args.length != 2) {
+      System.out.println(usage);
+      return;
+    }
+
+    String region = args[0];
+    String caArn = args[1];
+
+    // Create a client that you can use to make requests.
+    AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+
+    // Set the signed certificate.
+    String strCertificate =
+          "-----BEGIN CERTIFICATE-----\n" +
+          "base64-encoded certificate\n" +
+          "-----END CERTIFICATE-----\n";
+    SdkBytes certSdkBytes = SdkBytes.fromUtf8String(strCertificate);
+
+    // Set the certificate chain.
+    String strCertificateChain =
+          "-----BEGIN CERTIFICATE-----\n" +
+          "base64-encoded certificate\n" +
+          "-----END CERTIFICATE-----\n";
+    SdkBytes chainSdkBytes = SdkBytes.fromUtf8String(strCertificateChain);
+
+    // Create a request object with required parameters.
+    ImportCertificateAuthorityCertificateRequest req =
+        ImportCertificateAuthorityCertificateRequest.builder()
+            .certificateAuthorityArn(caArn)
+            .certificate(certSdkBytes)
+            .certificateChain(chainSdkBytes)
+            .build();
+            
+    try {
+      client.importCertificateAuthorityCertificate(req);
+    } catch (AcmPcaException ex) {
+      System.err.println(ex.awsErrorDetails().errorMessage());
+    }
+  }
+}
+// snippet-end:[acmpca.java2.ImportCertificateAuthorityCertificate.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
@@ -50,8 +50,8 @@ public class ImportCertificateAuthorityCertificate {
        * Read the signed certificate.
        * This assumes that a file named cert.pem is stored somewhere and contains the signed certificate
        */
-      String cert = Files.readString(Paths.get("cert.pem"), StandardCharsets.UTF_8);
-      SdkBytes certSdkBytes = SdkBytes.fromUtf8String(cert);
+      String signedCert = Files.readString(Paths.get("cert.pem"), StandardCharsets.UTF_8);
+      SdkBytes certSdkBytes = SdkBytes.fromUtf8String(signedCert);
 
       /*
        * Read the certificate chain.

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
@@ -8,6 +8,10 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.acmpca.AcmPcaClient;
 import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
 import software.amazon.awssdk.services.acmpca.model.ImportCertificateAuthorityCertificateRequest;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
 
 // snippet-start:[acmpca.java2.ImportCertificateAuthorityCertificate.main]
 /**
@@ -41,30 +45,32 @@ public class ImportCertificateAuthorityCertificate {
     // Create a client that you can use to make requests.
     AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
 
-    // Set the signed certificate.
-    String certificateStr =
-          "-----BEGIN CERTIFICATE-----\n" +
-          "base64-encoded certificate\n" +
-          "-----END CERTIFICATE-----\n";
-    SdkBytes certSdkBytes = SdkBytes.fromUtf8String(certificateStr);
-
-    // Set the certificate chain.
-    String certificateStrChain =
-          "-----BEGIN CERTIFICATE-----\n" +
-          "base64-encoded certificate\n" +
-          "-----END CERTIFICATE-----\n";
-    SdkBytes chainSdkBytes = SdkBytes.fromUtf8String(certificateStrChain);
-
-    // Create a request object with required parameters.
-    ImportCertificateAuthorityCertificateRequest req =
-        ImportCertificateAuthorityCertificateRequest.builder()
-            .certificateAuthorityArn(caArn)
-            .certificate(certSdkBytes)
-            .certificateChain(chainSdkBytes)
-            .build();
-            
     try {
+      /*
+       * Read the signed certificate.
+       * This assumes that a file named cert.pem is stored somewhere and contains the signed certificate
+       */
+      String cert = Files.readString(Paths.get("cert.pem"), StandardCharsets.UTF_8);
+      SdkBytes certSdkBytes = SdkBytes.fromUtf8String(cert);
+
+      /*
+       * Read the certificate chain.
+       * This assumes that a file named certChain.pem is stored somewhere and contains the certificate chain 
+       */
+      String certChain = Files.readString(Paths.get("certChain.pem"), StandardCharsets.UTF_8);
+      SdkBytes chainSdkBytes = SdkBytes.fromUtf8String(certChain);
+
+      ImportCertificateAuthorityCertificateRequest req =
+          ImportCertificateAuthorityCertificateRequest.builder()
+              .certificateAuthorityArn(caArn)
+              .certificate(certSdkBytes)
+              .certificateChain(chainSdkBytes)
+              .build();
+              
       client.importCertificateAuthorityCertificate(req);
+      
+    } catch (IOException ex) {
+      System.err.println("Error reading certificate file: " + ex.getMessage());
     } catch (AcmPcaException ex) {
       System.err.println(ex.awsErrorDetails().errorMessage());
     }

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/ImportCertificateAuthorityCertificate.java
@@ -42,18 +42,18 @@ public class ImportCertificateAuthorityCertificate {
     AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
 
     // Set the signed certificate.
-    String strCertificate =
+    String certificateStr =
           "-----BEGIN CERTIFICATE-----\n" +
           "base64-encoded certificate\n" +
           "-----END CERTIFICATE-----\n";
-    SdkBytes certSdkBytes = SdkBytes.fromUtf8String(strCertificate);
+    SdkBytes certSdkBytes = SdkBytes.fromUtf8String(certificateStr);
 
     // Set the certificate chain.
-    String strCertificateChain =
+    String certificateStrChain =
           "-----BEGIN CERTIFICATE-----\n" +
           "base64-encoded certificate\n" +
           "-----END CERTIFICATE-----\n";
-    SdkBytes chainSdkBytes = SdkBytes.fromUtf8String(strCertificateChain);
+    SdkBytes chainSdkBytes = SdkBytes.fromUtf8String(certificateStrChain);
 
     // Create a request object with required parameters.
     ImportCertificateAuthorityCertificateRequest req =

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/RestoreCertificateAuthority.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/RestoreCertificateAuthority.java
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException; 
+import software.amazon.awssdk.services.acmpca.model.RestoreCertificateAuthorityRequest;
+
+// snippet-start:[acmpca.java2.RestoreCertificateAuthority.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class RestoreCertificateAuthority {
+
+  public static void main(String[] args) throws Exception {
+
+    final String usage =
+        """
+            Usage: <region> <caArn>
+
+            Where:
+                region - The AWS region (e.g. us-east-1)
+                caArn - The ARN of the certificate authority
+            """;
+
+    if (args.length != 2) {
+      System.out.println(usage);
+      return;
+    }
+
+    String region = args[0];
+    String caArn = args[1];
+
+    // Create a client that you can use to make requests.
+    AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+
+    // Create the request object.
+    RestoreCertificateAuthorityRequest req =
+        RestoreCertificateAuthorityRequest.builder()
+            .certificateAuthorityArn(caArn)
+            .build();
+
+    try {
+      client.restoreCertificateAuthority(req);
+      System.out.println("CA Successfully Restored!");
+    } catch (AcmPcaException ex) {
+      System.err.println(ex.awsErrorDetails().errorMessage());
+    }
+  }
+}
+// snippet-end:[acmpca.java2.RestoreCertificateAuthority.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/RevokeCertificate.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/RevokeCertificate.java
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca;
+
+import software.amazon.awssdk.regions.Region;
+
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.RevocationReason;
+import software.amazon.awssdk.services.acmpca.model.RevokeCertificateRequest;
+
+// snippet-start:[acmpca.java2.RevokeCertificate.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class RevokeCertificate {
+
+  public static void main(String[] args) throws Exception {
+
+    final String usage =
+        """
+           Usage: <regionName> <caArn> <serial>
+
+           Where:
+                regionName - The AWS region (e.g. us-east-1)
+                caArn - The ARN of the certificate authority
+                serial - The Serial number for the Arn (ex. "79:3f:0d:5b:6a:04:12:5e:2c:9c:fb:52:37:35:98:fe")
+           """;
+
+    if (args.length != 3) {
+      System.out.println(usage);
+      return;
+    }
+
+    String region = args[0];
+    String caArn = args[1];
+    String serial = args[2];
+
+    // Create a client that you can use to make requests.
+    AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+
+    // Create a request object and set the revocation reason.
+    RevokeCertificateRequest req =
+        RevokeCertificateRequest.builder()
+            .certificateAuthorityArn(caArn) 
+            .certificateSerial(serial) 
+            .revocationReason(RevocationReason.KEY_COMPROMISE) 
+            .build();
+            
+    try {
+      client.revokeCertificate(req);
+    } catch (AcmPcaException ex) {
+       System.err.println(ex.awsErrorDetails().errorMessage());
+    } 
+  }
+}
+// snippet-end:[acmpca.java2.RevokeCertificate.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/RevokeCertificate.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/RevokeCertificate.java
@@ -54,8 +54,9 @@ public class RevokeCertificate {
             
     try {
       client.revokeCertificate(req);
+      System.out.println("Certificate Revoked!");
     } catch (AcmPcaException ex) {
-       System.err.println(ex.awsErrorDetails().errorMessage());
+      System.err.println(ex.awsErrorDetails().errorMessage());
     } 
   }
 }

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/UpdateCertificateAuthority.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/UpdateCertificateAuthority.java
@@ -52,7 +52,7 @@ public class UpdateCertificateAuthority {
         CrlConfiguration.builder()
             .enabled(true)
             .expirationInDays(365) 
-            .customCname("your-custom-name")
+            .customCname("your-custom-cname")
             .s3BucketName("your-bucket-name")
             .build();
     /*

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/UpdateCertificateAuthority.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/UpdateCertificateAuthority.java
@@ -55,11 +55,7 @@ public class UpdateCertificateAuthority {
             .customCname("your-custom-cname")
             .s3BucketName("your-bucket-name")
             .build();
-    /*
-     * Set the CRL configuration onto your UpdateCertificateAuthorityRequest object.
-     * If you do not want to change your CRL configuration, do not use the
-     * crlConfiguration method.
-     */
+            
     RevocationConfiguration revokeConfig =
         RevocationConfiguration.builder()
             .crlConfiguration(crlConfigure)

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/UpdateCertificateAuthority.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/UpdateCertificateAuthority.java
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityStatus;
+import software.amazon.awssdk.services.acmpca.model.CrlConfiguration;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.RevocationConfiguration;
+import software.amazon.awssdk.services.acmpca.model.UpdateCertificateAuthorityRequest;
+
+// snippet-start:[acmpca.java2.UpdateCertificateAuthority.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class UpdateCertificateAuthority {
+
+  public static void main(String[] args) throws Exception {
+
+    final String usage =
+        """
+            Usage: <region> <caArn>
+
+            Where:
+                region - The AWS region (e.g., us-east-1)
+                caArn - The ARN of the certificate authority
+            """;
+
+    if (args.length != 2) {
+      System.out.println(usage);
+      return;
+    }
+
+    String region = args[0];
+    String caArn = args[1];
+
+    // Create a client that you can use to make requests.
+    AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+
+    /*
+     * Define the certificate revocation list configuration. 
+     * If you do not want to update the CRL configuration, leave the CrlConfiguration structure alone and
+     * do not set it on your UpdateCertificateAuthorityRequest object.
+     */
+    CrlConfiguration crlConfigure =
+        CrlConfiguration.builder()
+            .enabled(true)
+            .expirationInDays(365) 
+            .customCname("your-custom-name")
+            .s3BucketName("your-bucket-name")
+            .build();
+    /*
+     * Set the CRL configuration onto your UpdateCertificateAuthorityRequest object.
+     * If you do not want to change your CRL configuration, do not use the
+     * crlConfiguration method.
+     */
+    RevocationConfiguration revokeConfig =
+        RevocationConfiguration.builder()
+            .crlConfiguration(crlConfigure)
+            .build(); 
+
+     // Create the request object.
+    UpdateCertificateAuthorityRequest req =
+        UpdateCertificateAuthorityRequest.builder()
+            .certificateAuthorityArn(caArn)
+            .status(CertificateAuthorityStatus.ACTIVE)
+            .revocationConfiguration(revokeConfig)
+            .build();
+      
+    try {
+      client.updateCertificateAuthority(req);
+      System.out.println("Sucessfully updated CA!");
+    } catch (AcmPcaException ex) {
+      System.err.println(ex.awsErrorDetails().errorMessage());
+    } 
+  }
+}
+// snippet-end:[acmpca.java2.UpdateCertificateAuthority.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
@@ -40,7 +40,7 @@ import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
  */
 public class CreatePrivateCertificateAuthorityAD{
-  
+
     public static void main(String[] args) throws Exception {
 
       final String usage =
@@ -183,7 +183,7 @@ public class CreatePrivateCertificateAuthorityAD{
     private static String getCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
       // Create a request object.
       GetCertificateRequest certificateRequest =
-            GetCertificateRequest.builder()
+          GetCertificateRequest.builder()
               .certificateArn(rootCertificateArn)
               .certificateAuthorityArn(rootCAArn)
               .build();

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
@@ -31,19 +31,6 @@ import software.amazon.awssdk.services.acmpca.model.SigningAlgorithm;
 import software.amazon.awssdk.services.acmpca.model.Validity;
 import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
-import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.bouncycastle.util.io.pem.PemReader;
-import java.util.Base64; 
-
-import lombok.SneakyThrows;
-
 // snippet-start:[acmpca.CreatePrivateCertificateAuthorityAD.main]
 /**
  * Before running this Java V2 code example, set up your development 
@@ -53,192 +40,193 @@ import lombok.SneakyThrows;
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
  */
 public class CreatePrivateCertificateAuthorityAD{
+  
     public static void main(String[] args) throws Exception {
-        final String usage =
-            """
-                Usage: <region> 
 
-                Where:
-                    region - The AWS region (e.g. us-east-1)
-                """;
+      final String usage =
+          """
+              Usage: <region> 
 
-        if (args.length != 1) {
-          System.out.println(usage);
-          return;
-        }
+              Where:
+                  region - The AWS region (e.g. us-east-1)
+              """;
 
-        String region = args[0];
+      if (args.length != 1) {
+        System.out.println(usage);
+        return;
+      }
 
-        // Define custom attributes
-        List<CustomAttribute> customAttributes = Arrays.asList(
-                CustomAttribute.builder()
-                        .objectIdentifier("2.5.4.3") // OID for Common Name
-                        .value("root CA")
-                .build(),
-                CustomAttribute.builder()
-                        .objectIdentifier("0.9.2342.19200300.100.1.25") // OID for Domain Component
-                        .value("example")
-                .build(),
-                CustomAttribute.builder()
-                        .objectIdentifier("0.9.2342.19200300.100.1.25") // OID for Domain Component
-                        .value("com")
-                .build()
-            
-        );
+      String region = args[0];
 
-        // Define a CA subject.
-        ASN1Subject subject = ASN1Subject.builder()
-                .customAttributes(customAttributes)
-                .build();
+      // Define custom attributes.
+      List<CustomAttribute> customAttributes = Arrays.asList(
+          CustomAttribute.builder()
+            .objectIdentifier("2.5.4.3") // OID for Common Name
+            .value("root CA")
+            .build(),
+          CustomAttribute.builder()
+            .objectIdentifier("0.9.2342.19200300.100.1.25") // OID for Domain Component
+            .value("example")
+            .build(),
+          CustomAttribute.builder()
+            .objectIdentifier("0.9.2342.19200300.100.1.25") // OID for Domain Component
+            .value("com")
+            .build()
+      );
 
-        // Define the CA configuration.
-        CertificateAuthorityConfiguration configCA = 
-            CertificateAuthorityConfiguration.builder()
-                .keyAlgorithm(KeyAlgorithm.EC_PRIME256_V1)
-                .signingAlgorithm(SigningAlgorithm.SHA256_WITHECDSA)
-                .subject(subject)
-                .build();
+      // Define a CA subject.
+      ASN1Subject subject = 
+          ASN1Subject.builder()
+              .customAttributes(customAttributes)
+              .build();
 
-        // Define a certificate authority type
-        CertificateAuthorityType CAtype = CertificateAuthorityType.ROOT;
+      // Define the CA configuration.
+      CertificateAuthorityConfiguration configCA = 
+          CertificateAuthorityConfiguration.builder()
+              .keyAlgorithm(KeyAlgorithm.EC_PRIME256_V1)
+              .signingAlgorithm(SigningAlgorithm.SHA256_WITHECDSA)
+              .subject(subject)
+              .build();
 
-        // ** Execute core code samples for Root CA activation in sequence **
-        AcmPcaClient client = ClientBuilder(region);
-        String rootCAArn = CreateCertificateAuthority(configCA, CAtype, client);
-        String csr = GetCertificateAuthorityCsr(rootCAArn, client);
-        String rootCertificateArn = IssueCertificate(rootCAArn, csr, client);
-        String rootCertificate = GetCertificate(rootCertificateArn, rootCAArn, client);
-        ImportCertificateAuthorityCertificate(rootCertificate, rootCAArn, client);
+      // Define a certificate authority type.
+      CertificateAuthorityType CAtype = CertificateAuthorityType.ROOT;
+
+      // Execute core code samples for Root CA activation in sequence.
+      AcmPcaClient client = createClient(region);
+      String rootCAArn = createCertificateAuthority(configCA, CAtype, client);
+      String csr = getCertificateAuthorityCsr(rootCAArn, client);
+      String rootCertificateArn = issueCertificate(rootCAArn, csr, client);
+      String rootCertificate = getCertificate(rootCertificateArn, rootCAArn, client);
+      importCertificateAuthorityCertificate(rootCertificate, rootCAArn, client);
     }
 
-    private static AcmPcaClient ClientBuilder(String region) {
-        AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
-        return client;
+    private static AcmPcaClient createClient(String region) {
+      AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+      return client;
     }
 
-    private static String CreateCertificateAuthority(CertificateAuthorityConfiguration configCA, CertificateAuthorityType CAtype, AcmPcaClient client) {
-        // Create the request object.
-        CreateCertificateAuthorityRequest createCARequest = CreateCertificateAuthorityRequest.builder()
-                .certificateAuthorityConfiguration(configCA)
-                .idempotencyToken("123987")
-                .certificateAuthorityType(CAtype)
-                .build();
-        
-        try {
-          CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
-          // Retrieve the ARN of the private CA.
-          String rootCAArn = createCAResult.certificateAuthorityArn();
-          System.out.println("Root CA Arn: " + rootCAArn);
-          return rootCAArn;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to create CA: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Certificate Authority creation failed", ex);
-        } 
+    private static String createCertificateAuthority(CertificateAuthorityConfiguration configCA, CertificateAuthorityType CAtype, AcmPcaClient client) {
+      // Create the request object.
+      CreateCertificateAuthorityRequest createCARequest = 
+          CreateCertificateAuthorityRequest.builder()
+              .certificateAuthorityConfiguration(configCA)
+              .idempotencyToken("123987")
+              .certificateAuthorityType(CAtype)
+              .build();
+      
+      try {
+        CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
+        // Retrieve the ARN of the private CA.
+        String rootCAArn = createCAResult.certificateAuthorityArn();
+        System.out.println("Root CA Arn: " + rootCAArn);
+        return rootCAArn;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to create CA: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Certificate Authority creation failed", ex);
+      } 
     }
 
-    private static String GetCertificateAuthorityCsr(String rootCAArn, AcmPcaClient client) {
+    private static String getCertificateAuthorityCsr(String rootCAArn, AcmPcaClient client) {
+      // Create the CSR request object.
+      GetCertificateAuthorityCsrRequest csrRequest = 
+          GetCertificateAuthorityCsrRequest.builder()
+              .certificateAuthorityArn(rootCAArn)
+              .build();
 
-        // Create the CSR request object.
-        GetCertificateAuthorityCsrRequest csrRequest = 
-            GetCertificateAuthorityCsrRequest.builder()
-                .certificateAuthorityArn(rootCAArn)
-                .build();
+      // Create waiter to wait on successful creation of the CSR file.
+      try (AcmPcaWaiter waiter = client.waiter()) {
+        waiter.waitUntilCertificateAuthorityCSRCreated(
+            b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }
 
-        // Create waiter to wait on successful creation of the CSR file.
-        try (AcmPcaWaiter waiter = client.waiter()) {
-         waiter.waitUntilCertificateAuthorityCSRCreated(
-             b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
-        } catch (AcmPcaException ex) {
-         System.err.println(ex.awsErrorDetails().errorMessage());
-        }
-
-        try {
-          GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
-          // Retrieve and display the CSR.
-          String csr = csrResult.csr();
-          System.out.println(csr);
-          return csr;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to get CSR: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
-        }
+      try {
+        GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
+        // Retrieve and display the CSR.
+        String csr = csrResult.csr();
+        System.out.println(csr);
+        return csr;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to get CSR: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
+      }
     }
 
-    private static String IssueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
+    private static String issueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
 
-        SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
+      SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
 
-        // Create a certificate request.
-        IssueCertificateRequest issueRequest = 
-            IssueCertificateRequest.builder()
-                .certificateAuthorityArn(rootCAArn)
-                .templateArn("arn:aws:acm-pca:::template/RootCACertificate/V1")
-                .signingAlgorithm(SigningAlgorithm.SHA256_WITHECDSA)
-                .validity(Validity.builder().value(3650L).type("DAYS").build())
-                .idempotencyToken("1234")
-                .csr(csrSdkBytes)
-                .build();
+      // Create a certificate request.
+      IssueCertificateRequest issueRequest = 
+          IssueCertificateRequest.builder()
+              .certificateAuthorityArn(rootCAArn)
+              .templateArn("arn:aws:acm-pca:::template/RootCACertificate/V1")
+              .signingAlgorithm(SigningAlgorithm.SHA256_WITHECDSA)
+              .validity(Validity.builder().value(3650L).type("DAYS").build())
+              .idempotencyToken("1234")
+              .csr(csrSdkBytes)
+              .build();
 
-        try {
-          IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
-          // Retrieve and display the certificate ARN.
-          String rootCertificateArn = issueResult.certificateArn();
-          System.out.println("Root Certificate Arn: " + rootCertificateArn);
-          return rootCertificateArn;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to issue certificate: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to issue certificate", ex);
-        }
+      try {
+        IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
+        // Retrieve and display the certificate ARN.
+        String rootCertificateArn = issueResult.certificateArn();
+        System.out.println("Root Certificate Arn: " + rootCertificateArn);
+        return rootCertificateArn;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to issue certificate: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to issue certificate", ex);
+      }
     }
     
-    private static String GetCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
+    private static String getCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
+      // Create a request object.
+      GetCertificateRequest certificateRequest =
+            GetCertificateRequest.builder()
+              .certificateArn(rootCertificateArn)
+              .certificateAuthorityArn(rootCAArn)
+              .build();
+              
+      // Create waiter to wait on successful creation of the certificate file.
+      try (AcmPcaWaiter waiter = client.waiter()) {
+        waiter.waitUntilCertificateIssued(
+            b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }
 
-        // Create a request object.
-        GetCertificateRequest certificateRequest =
-             GetCertificateRequest.builder()
-                .certificateArn(rootCertificateArn)
-                .certificateAuthorityArn(rootCAArn)
-                .build();
-                
-        // Create waiter to wait on successful creation of the certificate file.
-        try (AcmPcaWaiter waiter = client.waiter()) {
-          waiter.waitUntilCertificateIssued(
-              b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-        }
-
-        try {
-          GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
-          // Get the certificate and certificate chain and display the result.
-          String rootCertificate = certificateResult.certificate();
-          System.out.println(rootCertificate);
-          return rootCertificate;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to get certificate", ex);
-        }
+      try {
+        GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
+        // Get the certificate and certificate chain and display the result.
+        String rootCertificate = certificateResult.certificate();
+        System.out.println(rootCertificate);
+        return rootCertificate;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to get certificate", ex);
+      }
     }
 
-    private static void ImportCertificateAuthorityCertificate(String rootCertificate, String rootCAArn, AcmPcaClient client) {
+    private static void importCertificateAuthorityCertificate(String rootCertificate, String rootCAArn, AcmPcaClient client) {
         
-        SdkBytes certSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
+      SdkBytes certSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
 
-        // Create the request object.
-        ImportCertificateAuthorityCertificateRequest importRequest =
-            ImportCertificateAuthorityCertificateRequest.builder()
-                .certificate(certSdkBytes)
-                .certificateChain(null)
-                .certificateAuthorityArn(rootCAArn)
-                .build();
+      // Create the request object.
+      ImportCertificateAuthorityCertificateRequest importRequest =
+          ImportCertificateAuthorityCertificateRequest.builder()
+              .certificate(certSdkBytes)
+              .certificateChain(null)
+              .certificateAuthorityArn(rootCAArn)
+              .build();
 
-        try {
+      try {
           client.importCertificateAuthorityCertificate(importRequest);
           System.out.println("Root CA certificate successfully imported.");
           System.out.println("Root CA activated successfully.");
-        } catch (AcmPcaException ex) {
+      } catch (AcmPcaException ex) {
           System.err.println(ex.awsErrorDetails().errorMessage());
-        }
+      }
     }
 }
 // snippet-end:[acmpca.CreatePrivateCertificateAuthorityAD.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
@@ -1,4 +1,5 @@
-// package software.amazon.awssdk.services.appstream;
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package com.example.acmpca.scenarios;
 
@@ -43,6 +44,14 @@ import java.util.Base64;
 
 import lombok.SneakyThrows;
 
+// snippet-start:[acmpca.CreatePrivateCertificateAuthorityAD.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
 public class CreatePrivateCertificateAuthorityAD{
     public static void main(String[] args) throws Exception {
         final String usage =
@@ -232,3 +241,4 @@ public class CreatePrivateCertificateAuthorityAD{
         }
     }
 }
+// snippet-end:[acmpca.CreatePrivateCertificateAuthorityAD.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/CreatePrivateCertificateAuthorityAD.java
@@ -1,0 +1,234 @@
+// package software.amazon.awssdk.services.appstream;
+
+package com.example.acmpca.scenarios;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import java.util.Arrays;
+import java.util.List;
+
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.ASN1Subject;
+
+import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityConfiguration;
+import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityType;
+
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityResponse;
+import software.amazon.awssdk.services.acmpca.model.CustomAttribute;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCsrRequest;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCsrResponse;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateResponse;
+import software.amazon.awssdk.services.acmpca.model.ImportCertificateAuthorityCertificateRequest;
+
+import software.amazon.awssdk.services.acmpca.model.IssueCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.IssueCertificateResponse;
+import software.amazon.awssdk.services.acmpca.model.KeyAlgorithm;
+import software.amazon.awssdk.services.acmpca.model.SigningAlgorithm;
+import software.amazon.awssdk.services.acmpca.model.Validity;
+import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.util.io.pem.PemReader;
+import java.util.Base64; 
+
+import lombok.SneakyThrows;
+
+public class CreatePrivateCertificateAuthorityAD{
+    public static void main(String[] args) throws Exception {
+        final String usage =
+            """
+                Usage: <region> 
+
+                Where:
+                    region - The AWS region (e.g. us-east-1)
+                """;
+
+        if (args.length != 1) {
+          System.out.println(usage);
+          return;
+        }
+
+        String region = args[0];
+
+        // Define custom attributes
+        List<CustomAttribute> customAttributes = Arrays.asList(
+                CustomAttribute.builder()
+                        .objectIdentifier("2.5.4.3") // OID for Common Name
+                        .value("root CA")
+                .build(),
+                CustomAttribute.builder()
+                        .objectIdentifier("0.9.2342.19200300.100.1.25") // OID for Domain Component
+                        .value("example")
+                .build(),
+                CustomAttribute.builder()
+                        .objectIdentifier("0.9.2342.19200300.100.1.25") // OID for Domain Component
+                        .value("com")
+                .build()
+            
+        );
+
+        // Define a CA subject.
+        ASN1Subject subject = ASN1Subject.builder()
+                .customAttributes(customAttributes)
+                .build();
+
+        // Define the CA configuration.
+        CertificateAuthorityConfiguration configCA = 
+            CertificateAuthorityConfiguration.builder()
+                .keyAlgorithm(KeyAlgorithm.EC_PRIME256_V1)
+                .signingAlgorithm(SigningAlgorithm.SHA256_WITHECDSA)
+                .subject(subject)
+                .build();
+
+        // Define a certificate authority type
+        CertificateAuthorityType CAtype = CertificateAuthorityType.ROOT;
+
+        // ** Execute core code samples for Root CA activation in sequence **
+        AcmPcaClient client = ClientBuilder(region);
+        String rootCAArn = CreateCertificateAuthority(configCA, CAtype, client);
+        String csr = GetCertificateAuthorityCsr(rootCAArn, client);
+        String rootCertificateArn = IssueCertificate(rootCAArn, csr, client);
+        String rootCertificate = GetCertificate(rootCertificateArn, rootCAArn, client);
+        ImportCertificateAuthorityCertificate(rootCertificate, rootCAArn, client);
+    }
+
+    private static AcmPcaClient ClientBuilder(String region) {
+        AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+        return client;
+    }
+
+    private static String CreateCertificateAuthority(CertificateAuthorityConfiguration configCA, CertificateAuthorityType CAtype, AcmPcaClient client) {
+        // Create the request object.
+        CreateCertificateAuthorityRequest createCARequest = CreateCertificateAuthorityRequest.builder()
+                .certificateAuthorityConfiguration(configCA)
+                .idempotencyToken("123987")
+                .certificateAuthorityType(CAtype)
+                .build();
+        
+        try {
+          CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
+          // Retrieve the ARN of the private CA.
+          String rootCAArn = createCAResult.certificateAuthorityArn();
+          System.out.println("Root CA Arn: " + rootCAArn);
+          return rootCAArn;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to create CA: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Certificate Authority creation failed", ex);
+        } 
+    }
+
+    private static String GetCertificateAuthorityCsr(String rootCAArn, AcmPcaClient client) {
+
+        // Create the CSR request object.
+        GetCertificateAuthorityCsrRequest csrRequest = 
+            GetCertificateAuthorityCsrRequest.builder()
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+
+        // Create waiter to wait on successful creation of the CSR file.
+        try (AcmPcaWaiter waiter = client.waiter()) {
+         waiter.waitUntilCertificateAuthorityCSRCreated(
+             b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
+        } catch (AcmPcaException ex) {
+         System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+
+        try {
+          GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
+          // Retrieve and display the CSR.
+          String csr = csrResult.csr();
+          System.out.println(csr);
+          return csr;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to get CSR: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
+        }
+    }
+
+    private static String IssueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
+
+        SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
+
+        // Create a certificate request.
+        IssueCertificateRequest issueRequest = 
+            IssueCertificateRequest.builder()
+                .certificateAuthorityArn(rootCAArn)
+                .templateArn("arn:aws:acm-pca:::template/RootCACertificate/V1")
+                .signingAlgorithm(SigningAlgorithm.SHA256_WITHECDSA)
+                .validity(Validity.builder().value(3650L).type("DAYS").build())
+                .idempotencyToken("1234")
+                .csr(csrSdkBytes)
+                .build();
+
+        try {
+          IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
+          // Retrieve and display the certificate ARN.
+          String rootCertificateArn = issueResult.certificateArn();
+          System.out.println("Root Certificate Arn: " + rootCertificateArn);
+          return rootCertificateArn;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to issue certificate: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to issue certificate", ex);
+        }
+    }
+    
+    private static String GetCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
+
+        // Create a request object.
+        GetCertificateRequest certificateRequest =
+             GetCertificateRequest.builder()
+                .certificateArn(rootCertificateArn)
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+                
+        // Create waiter to wait on successful creation of the certificate file.
+        try (AcmPcaWaiter waiter = client.waiter()) {
+          waiter.waitUntilCertificateIssued(
+              b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+
+        try {
+          GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
+          // Get the certificate and certificate chain and display the result.
+          String rootCertificate = certificateResult.certificate();
+          System.out.println(rootCertificate);
+          return rootCertificate;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to get certificate", ex);
+        }
+    }
+
+    private static void ImportCertificateAuthorityCertificate(String rootCertificate, String rootCAArn, AcmPcaClient client) {
+        
+        SdkBytes certSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
+
+        // Create the request object.
+        ImportCertificateAuthorityCertificateRequest importRequest =
+            ImportCertificateAuthorityCertificateRequest.builder()
+                .certificate(certSdkBytes)
+                .certificateChain(null)
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+
+        try {
+          client.importCertificateAuthorityCertificate(importRequest);
+          System.out.println("Root CA certificate successfully imported.");
+          System.out.println("Root CA activated successfully.");
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+    }
+}

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/RootCAActivation.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/RootCAActivation.java
@@ -38,7 +38,7 @@ import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
  */
 public class RootCAActivation {
-  
+
     public static void main(String[] args) throws Exception {
 
       final String usage =
@@ -187,7 +187,7 @@ public class RootCAActivation {
     private static String getCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
       // Create a request object.
       GetCertificateRequest certificateRequest =
-            GetCertificateRequest.builder()
+          GetCertificateRequest.builder()
               .certificateArn(rootCertificateArn)
               .certificateAuthorityArn(rootCAArn)
               .build();

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/RootCAActivation.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/RootCAActivation.java
@@ -1,0 +1,238 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca.scenarios;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.ASN1Subject;
+import software.amazon.awssdk.regions.Region;
+
+import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityConfiguration;
+import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityType;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityResponse;
+import software.amazon.awssdk.services.acmpca.model.CrlConfiguration;
+
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCsrRequest;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCsrResponse;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateResponse;
+import software.amazon.awssdk.services.acmpca.model.ImportCertificateAuthorityCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.RevocationConfiguration;
+
+import software.amazon.awssdk.services.acmpca.model.IssueCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.IssueCertificateResponse;
+import software.amazon.awssdk.services.acmpca.model.KeyAlgorithm;
+import software.amazon.awssdk.services.acmpca.model.SigningAlgorithm;
+import software.amazon.awssdk.services.acmpca.model.Validity;
+import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
+
+// snippet-start:[acmpca.java2.RootCAActivation.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class RootCAActivation {
+    public static void main(String[] args) throws Exception {
+
+        final String usage =
+            """
+                Usage: <region> <s3BucketName>
+
+                Where:
+                    region - The AWS region (e.g. us-east-1)
+                    s3BucketName - The name of your bucket for CRL revocation
+                """;
+
+        if (args.length != 2) {
+          System.out.println(usage);
+          return;
+        }
+
+        String region = args[0];
+        String s3BucketName = args[1];
+
+
+        // Define a CA subject.
+        ASN1Subject subject = 
+            ASN1Subject.builder()
+                .organization("Example Organization")
+                .organizationalUnit("Example")
+                .country("US")
+                .state("Virginia")
+                .locality("Arlington")
+                .commonName("www.example.com")
+                .build();
+    
+        // Define the CA configuration.
+        CertificateAuthorityConfiguration configCA = 
+            CertificateAuthorityConfiguration.builder()
+                .keyAlgorithm(KeyAlgorithm.RSA_2048)
+                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+                .subject(subject)
+                .build();
+
+        // Define a certificate revocation list configuration.
+        CrlConfiguration crlConfigure = 
+            CrlConfiguration.builder()
+                .enabled(true)
+                .expirationInDays(365)
+                .customCname(null)
+                .s3BucketName(s3BucketName)
+                .build();
+
+        // Define a certificate authority type
+        CertificateAuthorityType CAtype = CertificateAuthorityType.ROOT;
+
+        // ** Execute core code samples for Root CA activation in sequence **
+        AcmPcaClient client = ClientBuilder(region);
+        String rootCAArn = CreateCertificateAuthority(configCA, crlConfigure, CAtype, client);
+        String csr = GetCertificateAuthorityCsr(rootCAArn, client);
+        String rootCertificateArn = IssueCertificate(rootCAArn, csr, client);
+        String rootCertificate = GetCertificate(rootCertificateArn, rootCAArn, client);
+        ImportCertificateAuthorityCertificate(rootCertificate, rootCAArn, client);
+    }
+
+    private static AcmPcaClient ClientBuilder(String region) {
+        AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+        return client;
+    }
+
+    private static String CreateCertificateAuthority(CertificateAuthorityConfiguration configCA, CrlConfiguration crlConfigure, CertificateAuthorityType CAtype, AcmPcaClient client) {
+        RevocationConfiguration revokeConfig = 
+            RevocationConfiguration.builder()
+                .crlConfiguration(crlConfigure)
+                .build();
+
+        // Create the request object.
+        CreateCertificateAuthorityRequest createCARequest = 
+            CreateCertificateAuthorityRequest.builder()
+                .certificateAuthorityConfiguration(configCA)
+                .revocationConfiguration(revokeConfig)
+                .idempotencyToken("123987")
+                .certificateAuthorityType(CAtype)
+                .build();
+       
+        try {
+          CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
+          // Retrieve the ARN of the private CA.
+          String rootCAArn = createCAResult.certificateAuthorityArn();
+          System.out.println("Root CA Arn: " + rootCAArn);
+          return rootCAArn;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to create CA: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Certificate Authority creation failed", ex);
+        } 
+    }
+
+    private static String GetCertificateAuthorityCsr(String rootCAArn, AcmPcaClient client) {
+
+        // Create the CSR request object.
+        GetCertificateAuthorityCsrRequest csrRequest = 
+            GetCertificateAuthorityCsrRequest.builder()
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+
+       // Create waiter to wait on successful creation of the CSR file.
+       try (AcmPcaWaiter waiter = client.waiter()) {
+         waiter.waitUntilCertificateAuthorityCSRCreated(
+             b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
+        } catch (AcmPcaException ex) {
+         System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+
+        try {
+          GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
+          // Retrieve and display the CSR.
+          String csr = csrResult.csr();
+          System.out.println(csr);
+          return csr;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to get CSR: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
+        }
+    }
+
+    private static String IssueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
+
+        SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
+
+        // Create a certificate request.
+        IssueCertificateRequest issueRequest = 
+            IssueCertificateRequest.builder()
+                .certificateAuthorityArn(rootCAArn)
+                .templateArn("arn:aws:acm-pca:::template/RootCACertificate/V1")
+                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+                .validity(Validity.builder().value(3650L).type("DAYS").build())
+                .idempotencyToken("1234")
+                .csr(csrSdkBytes)
+                .build();
+
+        try {
+          IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
+          // Retrieve and display the certificate ARN.
+          String rootCertificateArn = issueResult.certificateArn();
+          System.out.println("Root Certificate Arn: " + rootCertificateArn);
+          return rootCertificateArn;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to issue certificate: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to issue certificate", ex);
+        }
+    }
+    
+    private static String GetCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
+
+        // Create a request object.
+        GetCertificateRequest certificateRequest =
+             GetCertificateRequest.builder()
+                .certificateArn(rootCertificateArn)
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+
+        // Create waiter to wait on successful creation of the certificate file.
+        try (AcmPcaWaiter waiter = client.waiter()) {
+          waiter.waitUntilCertificateIssued(
+              b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+
+        try {
+          GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
+          // Get the certificate and certificate chain and display the result.
+          String rootCertificate = certificateResult.certificate();
+          System.out.println(rootCertificate);
+          return rootCertificate;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to get certificate", ex);
+        }
+    }
+
+    private static void ImportCertificateAuthorityCertificate(String rootCertificate, String rootCAArn, AcmPcaClient client) {
+
+        SdkBytes certSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
+
+        // Create the request object.
+        ImportCertificateAuthorityCertificateRequest importRequest =
+            ImportCertificateAuthorityCertificateRequest.builder()
+                .certificate(certSdkBytes)
+                .certificateChain(null)
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+
+        try {
+          client.importCertificateAuthorityCertificate(importRequest);
+          System.out.println("Root CA certificate successfully imported.");
+          System.out.println("Root CA activated successfully.");
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+    }
+}
+// snippet-end:[acmpca.java2.RootCAActivation.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/RootCAActivation.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/RootCAActivation.java
@@ -38,201 +38,199 @@ import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
  * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
  */
 public class RootCAActivation {
+  
     public static void main(String[] args) throws Exception {
 
-        final String usage =
-            """
-                Usage: <region> <s3BucketName>
+      final String usage =
+          """
+              Usage: <region> <s3BucketName>
 
-                Where:
-                    region - The AWS region (e.g. us-east-1)
-                    s3BucketName - The name of your bucket for CRL revocation
-                """;
+              Where:
+                  region - The AWS region (e.g. us-east-1)
+                  s3BucketName - The name of your bucket for CRL revocation
+              """;
 
-        if (args.length != 2) {
-          System.out.println(usage);
-          return;
-        }
+      if (args.length != 2) {
+        System.out.println(usage);
+        return;
+      }
 
-        String region = args[0];
-        String s3BucketName = args[1];
+      String region = args[0];
+      String s3BucketName = args[1];
 
+      // Define a CA subject.
+      ASN1Subject subject = 
+          ASN1Subject.builder()
+              .organization("Example Organization")
+              .organizationalUnit("Example")
+              .country("US")
+              .state("Virginia")
+              .locality("Arlington")
+              .commonName("www.example.com")
+              .build();
+  
+      // Define the CA configuration.
+      CertificateAuthorityConfiguration configCA = 
+          CertificateAuthorityConfiguration.builder()
+              .keyAlgorithm(KeyAlgorithm.RSA_2048)
+              .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+              .subject(subject)
+              .build();
 
-        // Define a CA subject.
-        ASN1Subject subject = 
-            ASN1Subject.builder()
-                .organization("Example Organization")
-                .organizationalUnit("Example")
-                .country("US")
-                .state("Virginia")
-                .locality("Arlington")
-                .commonName("www.example.com")
-                .build();
-    
-        // Define the CA configuration.
-        CertificateAuthorityConfiguration configCA = 
-            CertificateAuthorityConfiguration.builder()
-                .keyAlgorithm(KeyAlgorithm.RSA_2048)
-                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
-                .subject(subject)
-                .build();
+      // Define a certificate revocation list configuration.
+      CrlConfiguration crlConfigure = 
+          CrlConfiguration.builder()
+              .enabled(true)
+              .expirationInDays(365)
+              .customCname(null)
+              .s3BucketName(s3BucketName)
+              .build();
 
-        // Define a certificate revocation list configuration.
-        CrlConfiguration crlConfigure = 
-            CrlConfiguration.builder()
-                .enabled(true)
-                .expirationInDays(365)
-                .customCname(null)
-                .s3BucketName(s3BucketName)
-                .build();
+      // Define a certificate authority type.
+      CertificateAuthorityType CAtype = CertificateAuthorityType.ROOT;
 
-        // Define a certificate authority type
-        CertificateAuthorityType CAtype = CertificateAuthorityType.ROOT;
-
-        // ** Execute core code samples for Root CA activation in sequence **
-        AcmPcaClient client = ClientBuilder(region);
-        String rootCAArn = CreateCertificateAuthority(configCA, crlConfigure, CAtype, client);
-        String csr = GetCertificateAuthorityCsr(rootCAArn, client);
-        String rootCertificateArn = IssueCertificate(rootCAArn, csr, client);
-        String rootCertificate = GetCertificate(rootCertificateArn, rootCAArn, client);
-        ImportCertificateAuthorityCertificate(rootCertificate, rootCAArn, client);
+      // Execute core code samples for Root CA activation in sequence. 
+      AcmPcaClient client = createClient(region);
+      String rootCAArn = createCertificateAuthority(configCA, crlConfigure, CAtype, client);
+      String csr = getCertificateAuthorityCsr(rootCAArn, client);
+      String rootCertificateArn = issueCertificate(rootCAArn, csr, client);
+      String rootCertificate = getCertificate(rootCertificateArn, rootCAArn, client);
+      importCertificateAuthorityCertificate(rootCertificate, rootCAArn, client);
     }
 
-    private static AcmPcaClient ClientBuilder(String region) {
-        AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
-        return client;
+    private static AcmPcaClient createClient(String region) {
+      AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+      return client;
     }
 
-    private static String CreateCertificateAuthority(CertificateAuthorityConfiguration configCA, CrlConfiguration crlConfigure, CertificateAuthorityType CAtype, AcmPcaClient client) {
-        RevocationConfiguration revokeConfig = 
-            RevocationConfiguration.builder()
-                .crlConfiguration(crlConfigure)
-                .build();
+    private static String createCertificateAuthority(CertificateAuthorityConfiguration configCA, CrlConfiguration crlConfigure, CertificateAuthorityType CAtype, AcmPcaClient client) {
+      RevocationConfiguration revokeConfig = 
+          RevocationConfiguration.builder()
+              .crlConfiguration(crlConfigure)
+              .build();
 
-        // Create the request object.
-        CreateCertificateAuthorityRequest createCARequest = 
-            CreateCertificateAuthorityRequest.builder()
-                .certificateAuthorityConfiguration(configCA)
-                .revocationConfiguration(revokeConfig)
-                .idempotencyToken("123987")
-                .certificateAuthorityType(CAtype)
-                .build();
-       
-        try {
-          CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
-          // Retrieve the ARN of the private CA.
-          String rootCAArn = createCAResult.certificateAuthorityArn();
-          System.out.println("Root CA Arn: " + rootCAArn);
-          return rootCAArn;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to create CA: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Certificate Authority creation failed", ex);
-        } 
+      // Create the request object.
+      CreateCertificateAuthorityRequest createCARequest = 
+          CreateCertificateAuthorityRequest.builder()
+              .certificateAuthorityConfiguration(configCA)
+              .revocationConfiguration(revokeConfig)
+              .idempotencyToken("123987")
+              .certificateAuthorityType(CAtype)
+              .build();
+      
+      try {
+        CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
+        // Retrieve the ARN of the private CA.
+        String rootCAArn = createCAResult.certificateAuthorityArn();
+        System.out.println("Root CA Arn: " + rootCAArn);
+        return rootCAArn;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to create CA: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Certificate Authority creation failed", ex);
+      } 
     }
 
-    private static String GetCertificateAuthorityCsr(String rootCAArn, AcmPcaClient client) {
+    private static String getCertificateAuthorityCsr(String rootCAArn, AcmPcaClient client) {
+      // Create the CSR request object.
+      GetCertificateAuthorityCsrRequest csrRequest = 
+          GetCertificateAuthorityCsrRequest.builder()
+              .certificateAuthorityArn(rootCAArn)
+              .build();
 
-        // Create the CSR request object.
-        GetCertificateAuthorityCsrRequest csrRequest = 
-            GetCertificateAuthorityCsrRequest.builder()
-                .certificateAuthorityArn(rootCAArn)
-                .build();
+      // Create waiter to wait on successful creation of the CSR file.
+      try (AcmPcaWaiter waiter = client.waiter()) {
+        waiter.waitUntilCertificateAuthorityCSRCreated(
+            b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }
 
-       // Create waiter to wait on successful creation of the CSR file.
-       try (AcmPcaWaiter waiter = client.waiter()) {
-         waiter.waitUntilCertificateAuthorityCSRCreated(
-             b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
-        } catch (AcmPcaException ex) {
-         System.err.println(ex.awsErrorDetails().errorMessage());
-        }
-
-        try {
-          GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
-          // Retrieve and display the CSR.
-          String csr = csrResult.csr();
-          System.out.println(csr);
-          return csr;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to get CSR: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
-        }
+      try {
+        GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
+        // Retrieve and display the CSR.
+        String csr = csrResult.csr();
+        System.out.println(csr);
+        return csr;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to get CSR: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
+      }
     }
 
-    private static String IssueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
+    private static String issueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
 
-        SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
+      SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
 
-        // Create a certificate request.
-        IssueCertificateRequest issueRequest = 
-            IssueCertificateRequest.builder()
-                .certificateAuthorityArn(rootCAArn)
-                .templateArn("arn:aws:acm-pca:::template/RootCACertificate/V1")
-                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
-                .validity(Validity.builder().value(3650L).type("DAYS").build())
-                .idempotencyToken("1234")
-                .csr(csrSdkBytes)
-                .build();
+      // Create a certificate request.
+      IssueCertificateRequest issueRequest = 
+          IssueCertificateRequest.builder()
+              .certificateAuthorityArn(rootCAArn)
+              .templateArn("arn:aws:acm-pca:::template/RootCACertificate/V1")
+              .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+              .validity(Validity.builder().value(3650L).type("DAYS").build())
+              .idempotencyToken("1234")
+              .csr(csrSdkBytes)
+              .build();
 
-        try {
-          IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
-          // Retrieve and display the certificate ARN.
-          String rootCertificateArn = issueResult.certificateArn();
-          System.out.println("Root Certificate Arn: " + rootCertificateArn);
-          return rootCertificateArn;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to issue certificate: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to issue certificate", ex);
-        }
+      try {
+        IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
+        // Retrieve and display the certificate ARN.
+        String rootCertificateArn = issueResult.certificateArn();
+        System.out.println("Root Certificate Arn: " + rootCertificateArn);
+        return rootCertificateArn;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to issue certificate: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to issue certificate", ex);
+      }
     }
     
-    private static String GetCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
+    private static String getCertificate(String rootCertificateArn, String rootCAArn, AcmPcaClient client) {
+      // Create a request object.
+      GetCertificateRequest certificateRequest =
+            GetCertificateRequest.builder()
+              .certificateArn(rootCertificateArn)
+              .certificateAuthorityArn(rootCAArn)
+              .build();
 
-        // Create a request object.
-        GetCertificateRequest certificateRequest =
-             GetCertificateRequest.builder()
-                .certificateArn(rootCertificateArn)
-                .certificateAuthorityArn(rootCAArn)
-                .build();
+      // Create waiter to wait on successful creation of the certificate file.
+      try (AcmPcaWaiter waiter = client.waiter()) {
+        waiter.waitUntilCertificateIssued(
+            b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }
 
-        // Create waiter to wait on successful creation of the certificate file.
-        try (AcmPcaWaiter waiter = client.waiter()) {
-          waiter.waitUntilCertificateIssued(
-              b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-        }
-
-        try {
-          GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
-          // Get the certificate and certificate chain and display the result.
-          String rootCertificate = certificateResult.certificate();
-          System.out.println(rootCertificate);
-          return rootCertificate;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to get certificate", ex);
-        }
+      try {
+        GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
+        // Get the certificate and certificate chain and display the result.
+        String rootCertificate = certificateResult.certificate();
+        System.out.println(rootCertificate);
+        return rootCertificate;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to get certificate", ex);
+      }
     }
 
-    private static void ImportCertificateAuthorityCertificate(String rootCertificate, String rootCAArn, AcmPcaClient client) {
+    private static void importCertificateAuthorityCertificate(String rootCertificate, String rootCAArn, AcmPcaClient client) {
 
-        SdkBytes certSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
+      SdkBytes certSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
 
-        // Create the request object.
-        ImportCertificateAuthorityCertificateRequest importRequest =
-            ImportCertificateAuthorityCertificateRequest.builder()
-                .certificate(certSdkBytes)
-                .certificateChain(null)
-                .certificateAuthorityArn(rootCAArn)
-                .build();
+      // Create the request object.
+      ImportCertificateAuthorityCertificateRequest importRequest =
+          ImportCertificateAuthorityCertificateRequest.builder()
+              .certificate(certSdkBytes)
+              .certificateChain(null)
+              .certificateAuthorityArn(rootCAArn)
+              .build();
 
-        try {
-          client.importCertificateAuthorityCertificate(importRequest);
-          System.out.println("Root CA certificate successfully imported.");
-          System.out.println("Root CA activated successfully.");
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-        }
+      try {
+        client.importCertificateAuthorityCertificate(importRequest);
+        System.out.println("Root CA certificate successfully imported.");
+        System.out.println("Root CA activated successfully.");
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }
     }
 }
 // snippet-end:[acmpca.java2.RootCAActivation.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/SubordinateCAActivation.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/SubordinateCAActivation.java
@@ -215,7 +215,7 @@ public class SubordinateCAActivation {
     private static String getCertificate(String subordinateCertificateArn, String rootCAArn, AcmPcaClient client) {
       // Create a request object.
       GetCertificateRequest certificateRequest =
-            GetCertificateRequest.builder()
+          GetCertificateRequest.builder()
               .certificateArn(subordinateCertificateArn)
               .certificateAuthorityArn(rootCAArn)
               .build();

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/SubordinateCAActivation.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/SubordinateCAActivation.java
@@ -42,230 +42,225 @@ public class SubordinateCAActivation {
 
     public static void main(String[] args) throws Exception {
         
-        final String usage =
-            """
-                Usage: <region> <rootCAArn> <s3BucketName>
+      final String usage =
+          """
+              Usage: <region> <rootCAArn> <s3BucketName>
 
-                Where:
-                    region - The AWS region (e.g. us-east-1)
-                    rootArn - The ARN of the rootCA 
-                    s3BucketName - The name of your bucket for CRL revocation
-                """;
+              Where:
+                  region - The AWS region (e.g. us-east-1)
+                  rootArn - The ARN of the rootCA 
+                  s3BucketName - The name of your bucket for CRL revocation
+              """;
 
-        if (args.length != 3) {
-          System.out.println(usage);
-          return;
-        }
+      if (args.length != 3) {
+        System.out.println(usage);
+        return;
+      }
 
-        String region = args[0];
-        String rootArn = args[1];
-        String s3BucketName = args[2];
-        
-        // Place your own Root CA ARN here.
-        String rootCAArn = rootArn;
+      String region = args[0];
+      String rootArn = args[1];
+      String s3BucketName = args[2];
+      
+      // Place your own Root CA ARN here.
+      String rootCAArn = rootArn;
 
-        // Define a CA subject.
-        ASN1Subject subject = 
-            ASN1Subject.builder()
-                .organization("Example Organization")
-                .organizationalUnit("Example")
-                .country("US")
-                .state("Virginia")
-                .locality("Arlington")
-                .commonName("www.example.com")
-                .build();
+      // Define a CA subject.
+      ASN1Subject subject = 
+          ASN1Subject.builder()
+              .organization("Example Organization")
+              .organizationalUnit("Example")
+              .country("US")
+              .state("Virginia")
+              .locality("Arlington")
+              .commonName("www.example.com")
+              .build();
 
-        // Define the CA configuration.
-        CertificateAuthorityConfiguration configCA = 
-            CertificateAuthorityConfiguration.builder()
-                .keyAlgorithm(KeyAlgorithm.RSA_2048)
-                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
-                .subject(subject)
-                .build();
+      // Define the CA configuration.
+      CertificateAuthorityConfiguration configCA = 
+          CertificateAuthorityConfiguration.builder()
+              .keyAlgorithm(KeyAlgorithm.RSA_2048)
+              .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+              .subject(subject)
+              .build();
 
-       // Define a certificate revocation list configuration.
-        CrlConfiguration crlConfigure = 
-            CrlConfiguration.builder()
-                .enabled(true)
-                .expirationInDays(365)
-                .customCname(null)
-                .s3BucketName(s3BucketName)
-                .build();
+      // Define a certificate revocation list configuration.
+      CrlConfiguration crlConfigure = 
+          CrlConfiguration.builder()
+              .enabled(true)
+              .expirationInDays(365)
+              .customCname(null)
+              .s3BucketName(s3BucketName)
+              .build();
 
-        // Define a certificate authority type.
-        CertificateAuthorityType CAtype = CertificateAuthorityType.SUBORDINATE;
+      // Define a certificate authority type.
+      CertificateAuthorityType CAtype = CertificateAuthorityType.SUBORDINATE;
 
-        // ** Execute core code samples for Subordinate CA activation in sequence **
-        AcmPcaClient client = ClientBuilder(region);
-        String rootCertificate = GetCertificateAuthorityCertificate(rootCAArn, client);
-        String subordinateCAArn = CreateCertificateAuthority(configCA, crlConfigure, CAtype, client);
-        String csr = GetCertificateAuthorityCsr(subordinateCAArn, client);
-        String subordinateCertificateArn = IssueCertificate(rootCAArn, csr, client);
-        String subordinateCertificate = GetCertificate(subordinateCertificateArn, rootCAArn, client);
-        ImportCertificateAuthorityCertificate(subordinateCertificate, rootCertificate, subordinateCAArn, client);
-
+      // ** Execute core code samples for Subordinate CA activation in sequence **
+      AcmPcaClient client = createClient(region);
+      String rootCertificate = getCertificateAuthorityCertificate(rootCAArn, client);
+      String subordinateCAArn = createCertificateAuthority(configCA, crlConfigure, CAtype, client);
+      String csr = getCertificateAuthorityCsr(subordinateCAArn, client);
+      String subordinateCertificateArn = issueCertificate(rootCAArn, csr, client);
+      String subordinateCertificate = getCertificate(subordinateCertificateArn, rootCAArn, client);
+      importCertificateAuthorityCertificate(subordinateCertificate, rootCertificate, subordinateCAArn, client);
     }
 
-    private static AcmPcaClient ClientBuilder(String region) {
-        AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
-        return client;
+    private static AcmPcaClient createClient(String region) {
+      AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+      return client;
     }
 
-    private static String GetCertificateAuthorityCertificate(String rootCAArn, AcmPcaClient client) {
-
-        // Create a request object.
-        GetCertificateAuthorityCertificateRequest getCACertificateRequest =
-            GetCertificateAuthorityCertificateRequest.builder()
-                .certificateAuthorityArn(rootCAArn)
-                .build();
-        
-        try {
-          GetCertificateAuthorityCertificateResponse getCACertificateResult = client.getCertificateAuthorityCertificate(getCACertificateRequest);
-          // Retrieve and display the certificate information.
-          String rootCertificate = getCACertificateResult.certificate();
-          System.out.println("Root CA Certificate / Certificate Chain:");
-          System.out.println(rootCertificate);
-          return rootCertificate;
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Certificate Authority creation failed", ex);
-        } 
+    private static String getCertificateAuthorityCertificate(String rootCAArn, AcmPcaClient client) {
+      // Create a request object.
+      GetCertificateAuthorityCertificateRequest getCACertificateRequest =
+          GetCertificateAuthorityCertificateRequest.builder()
+              .certificateAuthorityArn(rootCAArn)
+              .build();
+      
+      try {
+        GetCertificateAuthorityCertificateResponse getCACertificateResult = client.getCertificateAuthorityCertificate(getCACertificateRequest);
+        // Retrieve and display the certificate information.
+        String rootCertificate = getCACertificateResult.certificate();
+        System.out.println("Root CA Certificate / Certificate Chain:");
+        System.out.println(rootCertificate);
+        return rootCertificate;
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Certificate Authority creation failed", ex);
+      } 
     }
 
-    private static String CreateCertificateAuthority(CertificateAuthorityConfiguration configCA, CrlConfiguration crlConfigure, CertificateAuthorityType CAtype, AcmPcaClient client) {
-         RevocationConfiguration revokeConfig = 
-            RevocationConfiguration.builder()
-                .crlConfiguration(crlConfigure)
-                .build();
+    private static String createCertificateAuthority(CertificateAuthorityConfiguration configCA, CrlConfiguration crlConfigure, CertificateAuthorityType CAtype, AcmPcaClient client) {
+      RevocationConfiguration revokeConfig = 
+        RevocationConfiguration.builder()
+            .crlConfiguration(crlConfigure)
+            .build();
 
-       // Create the request object.
-        CreateCertificateAuthorityRequest createCARequest = 
-            CreateCertificateAuthorityRequest.builder()
-                .certificateAuthorityConfiguration(configCA)
-                .revocationConfiguration(revokeConfig)
-                .idempotencyToken("123987")
-                .certificateAuthorityType(CAtype)
-                .build();
+      // Create the request object.
+      CreateCertificateAuthorityRequest createCARequest = 
+          CreateCertificateAuthorityRequest.builder()
+              .certificateAuthorityConfiguration(configCA)
+              .revocationConfiguration(revokeConfig)
+              .idempotencyToken("123987")
+              .certificateAuthorityType(CAtype)
+              .build();
 
-        try {
-          CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
-          // Retrieve the ARN of the private CA.
-          String subordinateCAArn = createCAResult.certificateAuthorityArn();
-          System.out.println("Subordinate CA Arn: " + subordinateCAArn);
-          return subordinateCAArn;
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Certificate Authority creation failed", ex);
-        }     
+      try {
+        CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
+        // Retrieve the ARN of the private CA.
+        String subordinateCAArn = createCAResult.certificateAuthorityArn();
+        System.out.println("Subordinate CA Arn: " + subordinateCAArn);
+        return subordinateCAArn;
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Certificate Authority creation failed", ex);
+      }     
     }
 
-    private static String GetCertificateAuthorityCsr(String subordinateCAArn, AcmPcaClient client) {
+    private static String getCertificateAuthorityCsr(String subordinateCAArn, AcmPcaClient client) {
+      // Create the CSR request object.
+      GetCertificateAuthorityCsrRequest csrRequest = 
+          GetCertificateAuthorityCsrRequest.builder()
+              .certificateAuthorityArn(subordinateCAArn)
+              .build();
 
-        // Create the CSR request object.
-        GetCertificateAuthorityCsrRequest csrRequest = 
-            GetCertificateAuthorityCsrRequest.builder()
-                .certificateAuthorityArn(subordinateCAArn)
-                .build();
+      // Create waiter to wait on successful creation of the CSR file.
+      try (AcmPcaWaiter waiter = client.waiter()) {
+        waiter.waitUntilCertificateAuthorityCSRCreated(
+            b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }
 
-        // Create waiter to wait on successful creation of the CSR file.
-        try (AcmPcaWaiter waiter = client.waiter()) {
-         waiter.waitUntilCertificateAuthorityCSRCreated(
-             b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-        }
-
-        try {
-          GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
-          // Retrieve and display the CSR.
-          String csr = csrResult.csr();
-          System.out.println("Subordinate CSR:");
-          System.out.println(csr);
-          return csr;
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
-        }
+      try {
+        GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
+        // Retrieve and display the CSR.
+        String csr = csrResult.csr();
+        System.out.println("Subordinate CSR:");
+        System.out.println(csr);
+        return csr;
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
+      }
     }
 
-    private static String IssueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
-        
-        SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
+    private static String issueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
+      
+      SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
 
-        // Create a certificate request.
-        IssueCertificateRequest issueRequest = 
-            IssueCertificateRequest.builder()
-                .certificateAuthorityArn(rootCAArn)
-                .templateArn("arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1")
-                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
-                .validity(Validity.builder().value(730L).type("DAYS").build())
-                .idempotencyToken("1234")
-                .csr(csrSdkBytes)
-                .build();
+      // Create a certificate request.
+      IssueCertificateRequest issueRequest = 
+          IssueCertificateRequest.builder()
+              .certificateAuthorityArn(rootCAArn)
+              .templateArn("arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1")
+              .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+              .validity(Validity.builder().value(730L).type("DAYS").build())
+              .idempotencyToken("1234")
+              .csr(csrSdkBytes)
+              .build();
 
-        try {
-          IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
-          // Retrieve and display the certificate ARN.
-          String subordinateCertificateArn = issueResult.certificateArn();
-          System.out.println("Subordinate Certificate Arn: " + subordinateCertificateArn);
-          return subordinateCertificateArn;
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to issue certificate", ex);
-        }
+      try {
+        IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
+        // Retrieve and display the certificate ARN.
+        String subordinateCertificateArn = issueResult.certificateArn();
+        System.out.println("Subordinate Certificate Arn: " + subordinateCertificateArn);
+        return subordinateCertificateArn;
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to issue certificate", ex);
+      }
     }
 
-    private static String GetCertificate(String subordinateCertificateArn, String rootCAArn, AcmPcaClient client) {
+    private static String getCertificate(String subordinateCertificateArn, String rootCAArn, AcmPcaClient client) {
+      // Create a request object.
+      GetCertificateRequest certificateRequest =
+            GetCertificateRequest.builder()
+              .certificateArn(subordinateCertificateArn)
+              .certificateAuthorityArn(rootCAArn)
+              .build();
+              
+      // Create waiter to wait on successful creation of the certificate file.
+      try (AcmPcaWaiter waiter = client.waiter()) {
+        waiter.waitUntilCertificateIssued(
+            b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }
 
-        // Create a request object.
-        GetCertificateRequest certificateRequest =
-             GetCertificateRequest.builder()
-                .certificateArn(subordinateCertificateArn)
-                .certificateAuthorityArn(rootCAArn)
-                .build();
-                
-        // Create waiter to wait on successful creation of the certificate file.
-        try (AcmPcaWaiter waiter = client.waiter()) {
-          waiter.waitUntilCertificateIssued(
-              b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-        }
-
-        try {
-          GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
-          // Get the certificate and certificate chain and display the result.
-          String subordinateCertificate = certificateResult.certificate();
-          System.out.println("Subordinate CA Certificate:");
-          System.out.println(subordinateCertificate);
-          return subordinateCertificate;
-        } catch (AcmPcaException ex) {
-          System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
-          throw new RuntimeException("Failed to get certificate", ex);
-        }
+      try {
+        GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
+        // Get the certificate and certificate chain and display the result.
+        String subordinateCertificate = certificateResult.certificate();
+        System.out.println("Subordinate CA Certificate:");
+        System.out.println(subordinateCertificate);
+        return subordinateCertificate;
+      } catch (AcmPcaException ex) {
+        System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
+        throw new RuntimeException("Failed to get certificate", ex);
+      }
     }
 
-    private static void ImportCertificateAuthorityCertificate(String subordinateCertificate, String rootCertificate, String subordinateCAArn, AcmPcaClient client) {
+    private static void importCertificateAuthorityCertificate(String subordinateCertificate, String rootCertificate, String subordinateCAArn, AcmPcaClient client) {
 
-       
-        SdkBytes certSdkBytes = SdkBytes.fromUtf8String(subordinateCertificate);
-        SdkBytes rootSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
+      SdkBytes certSdkBytes = SdkBytes.fromUtf8String(subordinateCertificate);
+      SdkBytes rootSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
 
-        // Create the request object.
-        ImportCertificateAuthorityCertificateRequest importRequest =
-            ImportCertificateAuthorityCertificateRequest.builder()
-                .certificate(certSdkBytes)
-                .certificateChain(rootSdkBytes)
-                .certificateAuthorityArn(subordinateCAArn)
-                .build();
+      // Create the request object.
+      ImportCertificateAuthorityCertificateRequest importRequest =
+          ImportCertificateAuthorityCertificateRequest.builder()
+              .certificate(certSdkBytes)
+              .certificateChain(rootSdkBytes)
+              .certificateAuthorityArn(subordinateCAArn)
+              .build();
 
-        try {
-          client.importCertificateAuthorityCertificate(importRequest);
-          System.out.println("Subordinate CA certificate successfully imported.");
-          System.out.println("Subordinate CA activated successfully.");
-        } catch (AcmPcaException ex) {
-          System.err.println(ex.awsErrorDetails().errorMessage());
-        }    
+      try {
+        client.importCertificateAuthorityCertificate(importRequest);
+        System.out.println("Subordinate CA certificate successfully imported.");
+        System.out.println("Subordinate CA activated successfully.");
+      } catch (AcmPcaException ex) {
+        System.err.println(ex.awsErrorDetails().errorMessage());
+      }    
     }
 }
 // snippet-end:[acmpca.java2.SubordinateCAActivation.main]

--- a/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/SubordinateCAActivation.java
+++ b/javav2/example_code/acmpca/src/main/java/com/example/acmpca/scenarios/SubordinateCAActivation.java
@@ -1,0 +1,271 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.example.acmpca.scenarios;
+
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.acmpca.model.KeyAlgorithm;
+import software.amazon.awssdk.services.acmpca.model.RevocationConfiguration;
+import software.amazon.awssdk.services.acmpca.model.SigningAlgorithm;
+import software.amazon.awssdk.services.acmpca.model.Validity;
+import software.amazon.awssdk.services.acmpca.waiters.AcmPcaWaiter;
+
+import software.amazon.awssdk.services.acmpca.AcmPcaClient;
+import software.amazon.awssdk.services.acmpca.model.AcmPcaException;
+import software.amazon.awssdk.services.acmpca.model.ASN1Subject;
+import software.amazon.awssdk.services.acmpca.model.CrlConfiguration;
+
+import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityConfiguration;
+import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityType;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityResponse;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCertificateResponse;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCsrRequest;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateAuthorityCsrResponse;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.GetCertificateResponse;
+import software.amazon.awssdk.services.acmpca.model.IssueCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.IssueCertificateResponse;
+import software.amazon.awssdk.services.acmpca.model.ImportCertificateAuthorityCertificateRequest;
+
+// snippet-start:[acmpca.java2.SubordinateCAActivation.main]
+/**
+ * Before running this Java V2 code example, set up your development 
+ * environment, including your credentials.
+ * 
+ * For more information, see the following documentation topic:
+ * https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/get-started.html
+ */
+public class SubordinateCAActivation {
+
+    public static void main(String[] args) throws Exception {
+        
+        final String usage =
+            """
+                Usage: <region> <rootCAArn> <s3BucketName>
+
+                Where:
+                    region - The AWS region (e.g. us-east-1)
+                    rootArn - The ARN of the rootCA 
+                    s3BucketName - The name of your bucket for CRL revocation
+                """;
+
+        if (args.length != 3) {
+          System.out.println(usage);
+          return;
+        }
+
+        String region = args[0];
+        String rootArn = args[1];
+        String s3BucketName = args[2];
+        
+        // Place your own Root CA ARN here.
+        String rootCAArn = rootArn;
+
+        // Define a CA subject.
+        ASN1Subject subject = 
+            ASN1Subject.builder()
+                .organization("Example Organization")
+                .organizationalUnit("Example")
+                .country("US")
+                .state("Virginia")
+                .locality("Arlington")
+                .commonName("www.example.com")
+                .build();
+
+        // Define the CA configuration.
+        CertificateAuthorityConfiguration configCA = 
+            CertificateAuthorityConfiguration.builder()
+                .keyAlgorithm(KeyAlgorithm.RSA_2048)
+                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+                .subject(subject)
+                .build();
+
+       // Define a certificate revocation list configuration.
+        CrlConfiguration crlConfigure = 
+            CrlConfiguration.builder()
+                .enabled(true)
+                .expirationInDays(365)
+                .customCname(null)
+                .s3BucketName(s3BucketName)
+                .build();
+
+        // Define a certificate authority type.
+        CertificateAuthorityType CAtype = CertificateAuthorityType.SUBORDINATE;
+
+        // ** Execute core code samples for Subordinate CA activation in sequence **
+        AcmPcaClient client = ClientBuilder(region);
+        String rootCertificate = GetCertificateAuthorityCertificate(rootCAArn, client);
+        String subordinateCAArn = CreateCertificateAuthority(configCA, crlConfigure, CAtype, client);
+        String csr = GetCertificateAuthorityCsr(subordinateCAArn, client);
+        String subordinateCertificateArn = IssueCertificate(rootCAArn, csr, client);
+        String subordinateCertificate = GetCertificate(subordinateCertificateArn, rootCAArn, client);
+        ImportCertificateAuthorityCertificate(subordinateCertificate, rootCertificate, subordinateCAArn, client);
+
+    }
+
+    private static AcmPcaClient ClientBuilder(String region) {
+        AcmPcaClient client = AcmPcaClient.builder().region(Region.of(region)).build();
+        return client;
+    }
+
+    private static String GetCertificateAuthorityCertificate(String rootCAArn, AcmPcaClient client) {
+
+        // Create a request object.
+        GetCertificateAuthorityCertificateRequest getCACertificateRequest =
+            GetCertificateAuthorityCertificateRequest.builder()
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+        
+        try {
+          GetCertificateAuthorityCertificateResponse getCACertificateResult = client.getCertificateAuthorityCertificate(getCACertificateRequest);
+          // Retrieve and display the certificate information.
+          String rootCertificate = getCACertificateResult.certificate();
+          System.out.println("Root CA Certificate / Certificate Chain:");
+          System.out.println(rootCertificate);
+          return rootCertificate;
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Certificate Authority creation failed", ex);
+        } 
+    }
+
+    private static String CreateCertificateAuthority(CertificateAuthorityConfiguration configCA, CrlConfiguration crlConfigure, CertificateAuthorityType CAtype, AcmPcaClient client) {
+         RevocationConfiguration revokeConfig = 
+            RevocationConfiguration.builder()
+                .crlConfiguration(crlConfigure)
+                .build();
+
+       // Create the request object.
+        CreateCertificateAuthorityRequest createCARequest = 
+            CreateCertificateAuthorityRequest.builder()
+                .certificateAuthorityConfiguration(configCA)
+                .revocationConfiguration(revokeConfig)
+                .idempotencyToken("123987")
+                .certificateAuthorityType(CAtype)
+                .build();
+
+        try {
+          CreateCertificateAuthorityResponse createCAResult = client.createCertificateAuthority(createCARequest);
+          // Retrieve the ARN of the private CA.
+          String subordinateCAArn = createCAResult.certificateAuthorityArn();
+          System.out.println("Subordinate CA Arn: " + subordinateCAArn);
+          return subordinateCAArn;
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Certificate Authority creation failed", ex);
+        }     
+    }
+
+    private static String GetCertificateAuthorityCsr(String subordinateCAArn, AcmPcaClient client) {
+
+        // Create the CSR request object.
+        GetCertificateAuthorityCsrRequest csrRequest = 
+            GetCertificateAuthorityCsrRequest.builder()
+                .certificateAuthorityArn(subordinateCAArn)
+                .build();
+
+        // Create waiter to wait on successful creation of the CSR file.
+        try (AcmPcaWaiter waiter = client.waiter()) {
+         waiter.waitUntilCertificateAuthorityCSRCreated(
+             b -> b.certificateAuthorityArn(csrRequest.certificateAuthorityArn()).build());
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+
+        try {
+          GetCertificateAuthorityCsrResponse csrResult = client.getCertificateAuthorityCsr(csrRequest);
+          // Retrieve and display the CSR.
+          String csr = csrResult.csr();
+          System.out.println("Subordinate CSR:");
+          System.out.println(csr);
+          return csr;
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to get Certificate Authority CSR", ex);
+        }
+    }
+
+    private static String IssueCertificate(String rootCAArn, String csr, AcmPcaClient client) {
+        
+        SdkBytes csrSdkBytes = SdkBytes.fromUtf8String(csr);
+
+        // Create a certificate request.
+        IssueCertificateRequest issueRequest = 
+            IssueCertificateRequest.builder()
+                .certificateAuthorityArn(rootCAArn)
+                .templateArn("arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1")
+                .signingAlgorithm(SigningAlgorithm.SHA256_WITHRSA)
+                .validity(Validity.builder().value(730L).type("DAYS").build())
+                .idempotencyToken("1234")
+                .csr(csrSdkBytes)
+                .build();
+
+        try {
+          IssueCertificateResponse issueResult = client.issueCertificate(issueRequest);
+          // Retrieve and display the certificate ARN.
+          String subordinateCertificateArn = issueResult.certificateArn();
+          System.out.println("Subordinate Certificate Arn: " + subordinateCertificateArn);
+          return subordinateCertificateArn;
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to issue certificate", ex);
+        }
+    }
+
+    private static String GetCertificate(String subordinateCertificateArn, String rootCAArn, AcmPcaClient client) {
+
+        // Create a request object.
+        GetCertificateRequest certificateRequest =
+             GetCertificateRequest.builder()
+                .certificateArn(subordinateCertificateArn)
+                .certificateAuthorityArn(rootCAArn)
+                .build();
+                
+        // Create waiter to wait on successful creation of the certificate file.
+        try (AcmPcaWaiter waiter = client.waiter()) {
+          waiter.waitUntilCertificateIssued(
+              b -> b.certificateArn(certificateRequest.certificateArn()).certificateAuthorityArn(certificateRequest.certificateAuthorityArn()).build());
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+        }
+
+        try {
+          GetCertificateResponse certificateResult = client.getCertificate(certificateRequest);
+          // Get the certificate and certificate chain and display the result.
+          String subordinateCertificate = certificateResult.certificate();
+          System.out.println("Subordinate CA Certificate:");
+          System.out.println(subordinateCertificate);
+          return subordinateCertificate;
+        } catch (AcmPcaException ex) {
+          System.err.println("Failed to get certificate: " + ex.awsErrorDetails().errorMessage());
+          throw new RuntimeException("Failed to get certificate", ex);
+        }
+    }
+
+    private static void ImportCertificateAuthorityCertificate(String subordinateCertificate, String rootCertificate, String subordinateCAArn, AcmPcaClient client) {
+
+       
+        SdkBytes certSdkBytes = SdkBytes.fromUtf8String(subordinateCertificate);
+        SdkBytes rootSdkBytes = SdkBytes.fromUtf8String(rootCertificate);
+
+        // Create the request object.
+        ImportCertificateAuthorityCertificateRequest importRequest =
+            ImportCertificateAuthorityCertificateRequest.builder()
+                .certificate(certSdkBytes)
+                .certificateChain(rootSdkBytes)
+                .certificateAuthorityArn(subordinateCAArn)
+                .build();
+
+        try {
+          client.importCertificateAuthorityCertificate(importRequest);
+          System.out.println("Subordinate CA certificate successfully imported.");
+          System.out.println("Subordinate CA activated successfully.");
+        } catch (AcmPcaException ex) {
+          System.err.println(ex.awsErrorDetails().errorMessage());
+        }    
+    }
+}
+// snippet-end:[acmpca.java2.SubordinateCAActivation.main]

--- a/javav2/example_code/acmpca/src/test/java/PCATests.java
+++ b/javav2/example_code/acmpca/src/test/java/PCATests.java
@@ -1,96 +1,242 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import com.example.acmpca.CreateCertificateAuthority;
+import com.example.acmpca.CreateCertificateAuthorityAuditReport;
+import com.example.acmpca.DescribeCertificateAuthorityAuditReport;
+import com.example.acmpca.ImportCertificateAuthorityCertificate;
+import com.example.acmpca.RestoreCertificateAuthority;
+import com.example.acmpca.RevokeCertificate;
+import com.example.acmpca.UpdateCertificateAuthority;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import software.amazon.awssdk.services.acmpca.AcmPcaClient;
-import software.amazon.awssdk.services.acmpca.model.*;
-import software.amazon.awssdk.services.acmpca.model.InvalidPolicyException;
-import software.amazon.awssdk.services.acmpca.model.LimitExceededException;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class PCATests {
+    private static final Logger logger = LoggerFactory.getLogger(PCATests.class);
 
-  @Mock private AcmPcaClient client;
-
-  // Sets up all mock objects to ensure that they are ready to use
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.openMocks(this);
-  }
-
-  @Test
-  void testCreateCA() {
-
-    // Fake arn expected
-    String expectedArn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca-id";
-
-    CreateCertificateAuthorityResponse mockResponse =
-        CreateCertificateAuthorityResponse.builder().certificateAuthorityArn(expectedArn).build();
-
-    when(client.createCertificateAuthority(any(CreateCertificateAuthorityRequest.class)))
-        .thenReturn(mockResponse);
-
-    CreateCertificateAuthorityResponse rootResult =
-        client.createCertificateAuthority(
-            CreateCertificateAuthorityRequest.builder()
-                .certificateAuthorityType(CertificateAuthorityType.ROOT)
-                .build());
-
-    CreateCertificateAuthorityResponse subResult =
-        client.createCertificateAuthority(
-            CreateCertificateAuthorityRequest.builder()
-                .certificateAuthorityType(CertificateAuthorityType.SUBORDINATE)
-                .build());
-
-    assertNotNull(rootResult);
-    assertNotNull(subResult);
-    assertEquals(expectedArn, rootResult.certificateAuthorityArn());
-    assertEquals(expectedArn, subResult.certificateAuthorityArn());
-    verify(client, times(2))
-        .createCertificateAuthority(any(CreateCertificateAuthorityRequest.class));
-  }
-
-  @Test
-  void testCreateCA_InvalidArgsException() {
-    // Test exception handling
-    when(client.createCertificateAuthority(any(CreateCertificateAuthorityRequest.class)))
-        .thenThrow(InvalidArgsException.builder().message("Invalid arguments").build());
-
-    // Verify exception is thrown
-    assertThrows(
-        InvalidArgsException.class,
-        () -> {
-          client.createCertificateAuthority(CreateCertificateAuthorityRequest.builder().build());
+    @Test
+    @Order(18)
+    public void testCreateCertificateAuthority() {
+        assertDoesNotThrow(() -> {
+            try {
+                CreateCertificateAuthority.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthority (invalid args): {}", e.getMessage());
+            }
+            try {
+                CreateCertificateAuthority.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthority (no args): {}", e.getMessage());
+            }
+            try {
+                CreateCertificateAuthority.main(new String[]{"us-east-1", "test-bucket", "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthority (too many args): {}", e.getMessage());
+            }
+            try {
+                CreateCertificateAuthority.main(new String[]{"us-east-1", "test-bucket"});
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthority (AWS call): {}", e.getMessage());
+            }
         });
-  }
+        logger.info("Test 18 passed");
+    }
 
-  @Test
-  void testCreateCA_InvalidPolicyException() {
-    when(client.createCertificateAuthority(any(CreateCertificateAuthorityRequest.class)))
-        .thenThrow(InvalidPolicyException.builder().message("Invalid policy").build());
-
-    assertThrows(
-        InvalidPolicyException.class,
-        () -> {
-          client.createCertificateAuthority(CreateCertificateAuthorityRequest.builder().build());
+    @Test
+    @Order(19)
+    public void testCreateCertificateAuthorityAuditReport() {
+        assertDoesNotThrow(() -> {
+            try {
+                CreateCertificateAuthorityAuditReport.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthorityAuditReport (invalid args): {}", e.getMessage());
+            }
+            try {
+                CreateCertificateAuthorityAuditReport.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthorityAuditReport (no args): {}", e.getMessage());
+            }
+            try {
+                CreateCertificateAuthorityAuditReport.main(new String[]{"us-east-1", 
+                    "test-bucket", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthorityAuditReport (too many args): {}", e.getMessage());
+            }
+            try {
+                CreateCertificateAuthorityAuditReport.main(new String[]{"us-east-1", 
+                    "test-bucket", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca"});
+            } catch (Exception e) {
+                logger.info("Expected exception in CreateCertificateAuthorityAuditReport (AWS call): {}", e.getMessage());
+            }
         });
-  }
+        logger.info("Test 19 passed");
+    }
 
-  @Test
-  void testCreateCA_LimitExceededException() {
-    when(client.createCertificateAuthority(any(CreateCertificateAuthorityRequest.class)))
-        .thenThrow(LimitExceededException.builder().message("Limit exceeded").build());
-
-    assertThrows(
-        LimitExceededException.class,
-        () -> {
-          client.createCertificateAuthority(CreateCertificateAuthorityRequest.builder().build());
+    @Test
+    @Order(20)
+    public void testDescribeCertificateAuthorityAuditReport() {
+        assertDoesNotThrow(() -> {
+            try {
+                DescribeCertificateAuthorityAuditReport.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in DescribeCertificateAuthorityAuditReport (invalid args): {}", e.getMessage());
+            }
+            try {
+                DescribeCertificateAuthorityAuditReport.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in DescribeCertificateAuthorityAuditReport (no args): {}", e.getMessage());
+            }
+            try {
+                DescribeCertificateAuthorityAuditReport.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "11111111-2222-3333-4444-555555555555", 
+                    "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in DescribeCertificateAuthorityAuditReport (too many args): {}", e.getMessage());
+            }
+            try {
+                DescribeCertificateAuthorityAuditReport.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "11111111-2222-3333-4444-555555555555"});
+            } catch (Exception e) {
+                logger.info("Expected exception in DescribeCertificateAuthorityAuditReport (AWS call): {}", e.getMessage());
+            }
         });
-  }
+        logger.info("Test 20 passed");
+    }
+
+    @Test
+    @Order(21)
+    public void testImportCertificateAuthorityCertificate() {
+        assertDoesNotThrow(() -> {
+            try {
+                ImportCertificateAuthorityCertificate.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in ImportCertificateAuthorityCertificate (invalid args): {}", e.getMessage());
+            }
+            try {
+                ImportCertificateAuthorityCertificate.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in ImportCertificateAuthorityCertificate (no args): {}", e.getMessage());
+            }
+            try {
+                ImportCertificateAuthorityCertificate.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in ImportCertificateAuthorityCertificate (too many args): {}", e.getMessage());
+            }
+            try {
+                ImportCertificateAuthorityCertificate.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca"});
+            } catch (Exception e) {
+                logger.info("Expected exception in ImportCertificateAuthorityCertificate (AWS call): {}", e.getMessage());
+            }
+        });
+        logger.info("Test 21 passed");
+    }
+
+    @Test
+    @Order(22)
+    public void testRestoreCertificateAuthority() {
+        assertDoesNotThrow(() -> {
+            try {
+                RestoreCertificateAuthority.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RestoreCertificateAuthority (invalid args): {}", e.getMessage());
+            }
+            try {
+                RestoreCertificateAuthority.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RestoreCertificateAuthority (no args): {}", e.getMessage());
+            }
+            try {
+                RestoreCertificateAuthority.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RestoreCertificateAuthority (too many args): {}", e.getMessage());
+            }
+            try {
+                RestoreCertificateAuthority.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca"});
+            } catch (Exception e) {
+                logger.info("Expected exception in RestoreCertificateAuthority (AWS call): {}", e.getMessage());
+            }
+        });
+        logger.info("Test 22 passed");
+    }
+
+    @Test
+    @Order(23)
+    public void testRevokeCertificate() {
+        assertDoesNotThrow(() -> {
+            try {
+                RevokeCertificate.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RevokeCertificate (invalid args): {}", e.getMessage());
+            }
+            try {
+                RevokeCertificate.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RevokeCertificate (no args): {}", e.getMessage());
+            }
+            try {
+                RevokeCertificate.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "79:3f:0d:5b:6a:04:12:5e:2c:9c:fb:52:37:35:98:fe", 
+                    "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RevokeCertificate (too many args): {}", e.getMessage());
+            }
+            try {
+                RevokeCertificate.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "79:3f:0d:5b:6a:04:12:5e:2c:9c:fb:52:37:35:98:fe"});
+            } catch (Exception e) {
+                logger.info("Expected exception in RevokeCertificate (AWS call): {}", e.getMessage());
+            }
+        });
+        logger.info("Test 23 passed");
+    }
+
+    @Test
+    @Order(24)
+    public void testUpdateCertificateAuthority() {
+        assertDoesNotThrow(() -> {
+            try {
+                UpdateCertificateAuthority.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in UpdateCertificateAuthority (invalid args): {}", e.getMessage());
+            }
+            try {
+                UpdateCertificateAuthority.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in UpdateCertificateAuthority (no args): {}", e.getMessage());
+            }
+            try {
+                UpdateCertificateAuthority.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca", 
+                    "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in UpdateCertificateAuthority (too many args): {}", e.getMessage());
+            }
+            try {
+                UpdateCertificateAuthority.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca"});
+            } catch (Exception e) {
+                logger.info("Expected exception in UpdateCertificateAuthority (AWS call): {}", e.getMessage());
+            }
+        });
+        logger.info("Test 24 passed");
+    }
 }

--- a/javav2/example_code/acmpca/src/test/java/PCATests.java
+++ b/javav2/example_code/acmpca/src/test/java/PCATests.java
@@ -8,6 +8,9 @@ import com.example.acmpca.ImportCertificateAuthorityCertificate;
 import com.example.acmpca.RestoreCertificateAuthority;
 import com.example.acmpca.RevokeCertificate;
 import com.example.acmpca.UpdateCertificateAuthority;
+import com.example.acmpca.scenarios.CreatePrivateCertificateAuthorityAD;
+import com.example.acmpca.scenarios.RootCAActivation;
+import com.example.acmpca.scenarios.SubordinateCAActivation;
 
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
@@ -238,5 +241,93 @@ public class PCATests {
             }
         });
         logger.info("Test 24 passed");
+    }
+
+    @Test
+    @Order(25)
+    public void testCreatePrivateCertificateAuthorityAD() {
+        assertDoesNotThrow(() -> {
+            try {
+                CreatePrivateCertificateAuthorityAD.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreatePrivateCertificateAuthorityAD (no args): {}", e.getMessage());
+            }
+            try {
+                CreatePrivateCertificateAuthorityAD.main(new String[]{"us-east-1", "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in CreatePrivateCertificateAuthorityAD (too many args): {}", e.getMessage());
+            }
+            try {
+                CreatePrivateCertificateAuthorityAD.main(new String[]{"us-east-1"});
+            } catch (Exception e) {
+                logger.info("Expected exception in CreatePrivateCertificateAuthorityAD (AWS call): {}", e.getMessage());
+            }
+        });
+        logger.info("Test 25 passed");
+    }
+
+    @Test
+    @Order(26)
+    public void testRootCAActivation() {
+        assertDoesNotThrow(() -> {
+            try {
+                RootCAActivation.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RootCAActivation (no args): {}", e.getMessage());
+            }
+            try {
+                RootCAActivation.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RootCAActivation (missing bucket arg): {}", e.getMessage());
+            }
+            try {
+                RootCAActivation.main(new String[]{"us-east-1", "test-bucket", "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in RootCAActivation (too many args): {}", e.getMessage());
+            }
+            try {
+                RootCAActivation.main(new String[]{"us-east-1", "test-bucket"});
+            } catch (Exception e) {
+                logger.info("Expected exception in RootCAActivation (AWS call): {}", e.getMessage());
+            }
+        });
+        logger.info("Test 26 passed");
+    }
+
+    @Test
+    @Order(27)
+    public void testSubordinateCAActivation() {
+        assertDoesNotThrow(() -> {
+            try {
+                SubordinateCAActivation.main(new String[]{}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in SubordinateCAActivation (no args): {}", e.getMessage());
+            }
+            try {
+                SubordinateCAActivation.main(new String[]{"us-east-1"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in SubordinateCAActivation (missing args): {}", e.getMessage());
+            }
+            try {
+                SubordinateCAActivation.main(new String[]{"us-east-1", "test-root-ca-arn"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in SubordinateCAActivation (missing bucket arg): {}", e.getMessage());
+            }
+            try {
+                SubordinateCAActivation.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-root-ca", 
+                    "test-bucket", "extra-arg"}); 
+            } catch (Exception e) {
+                logger.info("Expected exception in SubordinateCAActivation (too many args): {}", e.getMessage());
+            }
+            try {
+                SubordinateCAActivation.main(new String[]{"us-east-1", 
+                    "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-root-ca", 
+                    "test-bucket"});
+            } catch (Exception e) {
+                logger.info("Expected exception in SubordinateCAActivation (AWS call): {}", e.getMessage());
+            }
+        });
+        logger.info("Test 27 passed");
     }
 }

--- a/javav2/example_code/acmpca/src/test/java/PCATests.java
+++ b/javav2/example_code/acmpca/src/test/java/PCATests.java
@@ -2,27 +2,40 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import com.example.acmpca.CreateCertificateAuthority;
+import com.example.acmpca.CreateCertificateAuthorityAuditReport;
 import com.example.acmpca.CreatePermission;
 import com.example.acmpca.DeleteCertificateAuthority;
 import com.example.acmpca.DeletePermission;
 import com.example.acmpca.DeletePolicy;
 import com.example.acmpca.DescribeCertificateAuthority;
+import com.example.acmpca.DescribeCertificateAuthorityAuditReport;
 import com.example.acmpca.GetCertificate;
 import com.example.acmpca.GetCertificateAuthorityCertificate;
 import com.example.acmpca.GetCertificateAuthorityCsr;
 import com.example.acmpca.GetPolicy;
+import com.example.acmpca.ImportCertificateAuthorityCertificate;
 import com.example.acmpca.IssueCertificate;
 import com.example.acmpca.ListCertificateAuthorities;
 import com.example.acmpca.ListPermissions;
 import com.example.acmpca.ListTags;
 import com.example.acmpca.PutPolicy;
+import com.example.acmpca.RestoreCertificateAuthority;
+import com.example.acmpca.RevokeCertificate;
 import com.example.acmpca.TagCertificateAuthorities;
 import com.example.acmpca.UntagCertificateAuthority;
+import com.example.acmpca.UpdateCertificateAuthority;
+import com.example.acmpca.scenarios.CreatePrivateCertificateAuthorityAD;
+import com.example.acmpca.scenarios.RootCAActivation;
+import com.example.acmpca.scenarios.SubordinateCAActivation;
 
 import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityResponse;
 import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityAuditReportResponse;
+import software.amazon.awssdk.services.acmpca.model.CreateCertificateAuthorityAuditReportRequest;
 import software.amazon.awssdk.services.acmpca.model.DescribeCertificateAuthorityResponse;
 import software.amazon.awssdk.services.acmpca.model.DescribeCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.DescribeCertificateAuthorityAuditReportResponse;
+import software.amazon.awssdk.services.acmpca.model.DescribeCertificateAuthorityAuditReportRequest;
 import software.amazon.awssdk.services.acmpca.model.CertificateAuthority;
 import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityStatus;
 import software.amazon.awssdk.services.acmpca.model.CertificateAuthorityType;
@@ -58,6 +71,11 @@ import software.amazon.awssdk.services.acmpca.model.TagCertificateAuthorityRespo
 import software.amazon.awssdk.services.acmpca.model.TagCertificateAuthorityRequest;
 import software.amazon.awssdk.services.acmpca.model.UntagCertificateAuthorityResponse;
 import software.amazon.awssdk.services.acmpca.model.UntagCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.ImportCertificateAuthorityCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.RestoreCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.RevokeCertificateRequest;
+import software.amazon.awssdk.services.acmpca.model.UpdateCertificateAuthorityRequest;
+import software.amazon.awssdk.services.acmpca.model.AuditReportStatus;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Order;
@@ -641,6 +659,326 @@ public class PCATests {
             verifyNoInteractions(mockClient);
         }
         originalOut.println("Test 17 passed");
+    }
+
+    @Test
+    @Order(18)
+    public void testCreateCertificateAuthorityAuditReport() {
+        CreateCertificateAuthorityAuditReportResponse mockResponse = CreateCertificateAuthorityAuditReportResponse.builder()
+                .auditReportId("test-audit-report-id")
+                .s3Key("audit-reports/test-audit-report.json")
+                .build();
+        
+        when(mockClient.createCertificateAuthorityAuditReport(any(CreateCertificateAuthorityAuditReportRequest.class)))
+                .thenReturn(mockResponse);
+
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> CreateCertificateAuthorityAuditReport.main(new String[]{
+                "us-east-1", 
+                "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca",
+                "test-bucket"
+            }));
+            verify(mockClient).createCertificateAuthorityAuditReport(any(CreateCertificateAuthorityAuditReportRequest.class));
+            assertTrue(outputStream.toString().contains("test-audit-report-id"), "Should output audit report ID");
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> CreateCertificateAuthorityAuditReport.main(new String[]{"us-east-1"}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 18 passed");
+    }
+
+    @Test
+    @Order(19)
+    public void testDescribeCertificateAuthorityAuditReport() {
+        DescribeCertificateAuthorityAuditReportResponse mockResponse = DescribeCertificateAuthorityAuditReportResponse.builder()
+                .auditReportStatus(AuditReportStatus.SUCCESS)
+                .s3BucketName("test-bucket")
+                .s3Key("audit-reports/test-audit-report.json")
+                .build();
+        
+        when(mockClient.describeCertificateAuthorityAuditReport(any(DescribeCertificateAuthorityAuditReportRequest.class)))
+                .thenReturn(mockResponse);
+
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> DescribeCertificateAuthorityAuditReport.main(new String[]{
+                "us-east-1", 
+                "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca",
+                "test-audit-report-id"
+            }));
+            verify(mockClient).describeCertificateAuthorityAuditReport(any(DescribeCertificateAuthorityAuditReportRequest.class));
+            assertTrue(outputStream.toString().contains("SUCCESS"), "Should output audit report status");
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> DescribeCertificateAuthorityAuditReport.main(new String[]{"us-east-1"}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 19 passed");
+    }
+
+    @Test
+    @Order(20)
+    public void testImportCertificateAuthorityCertificate() {
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class);
+             MockedStatic<Files> mockedFiles = mockStatic(Files.class);
+             MockedStatic<Paths> mockedPaths = mockStatic(Paths.class)) {
+            
+            setupMockClient(mockedStatic);
+            
+            Path mockCertPath = mock(Path.class);
+            Path mockChainPath = mock(Path.class);
+            String mockCertContent = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE-----";
+            String mockChainContent = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE-----";
+            
+            mockedPaths.when(() -> Paths.get("cert.pem")).thenReturn(mockCertPath);
+            mockedPaths.when(() -> Paths.get("certChain.pem")).thenReturn(mockChainPath);
+            mockedFiles.when(() -> Files.readString(mockCertPath, StandardCharsets.UTF_8)).thenReturn(mockCertContent);
+            mockedFiles.when(() -> Files.readString(mockChainPath, StandardCharsets.UTF_8)).thenReturn(mockChainContent);
+            
+            assertDoesNotThrow(() -> ImportCertificateAuthorityCertificate.main(new String[]{
+                "us-east-1", 
+                "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca"
+            }));
+            verify(mockClient).importCertificateAuthorityCertificate(any(ImportCertificateAuthorityCertificateRequest.class));
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> ImportCertificateAuthorityCertificate.main(new String[]{"us-east-1"}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 20 passed");
+    }
+
+    @Test
+    @Order(21)
+    public void testRestoreCertificateAuthority() {
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> RestoreCertificateAuthority.main(new String[]{
+                "us-east-1", 
+                "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca"
+            }));
+            verify(mockClient).restoreCertificateAuthority(any(RestoreCertificateAuthorityRequest.class));
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> RestoreCertificateAuthority.main(new String[]{}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 21 passed");
+    }
+
+    @Test
+    @Order(22)
+    public void testRevokeCertificate() {
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> RevokeCertificate.main(new String[]{
+                "us-east-1", 
+                "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca",
+                "arn:aws:acm-pca:us-east-1:123456789012:certificate/test-cert"
+            }));
+            verify(mockClient).revokeCertificate(any(RevokeCertificateRequest.class));
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> RevokeCertificate.main(new String[]{"us-east-1"}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 22 passed");
+    }
+
+    @Test
+    @Order(23)
+    public void testUpdateCertificateAuthority() {
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> UpdateCertificateAuthority.main(new String[]{
+                "us-east-1", 
+                "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca"
+            }));
+            verify(mockClient).updateCertificateAuthority(any(UpdateCertificateAuthorityRequest.class));
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> UpdateCertificateAuthority.main(new String[]{}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 23 passed");
+    }
+
+    @Test
+    @Order(24)
+    public void testCreatePrivateCertificateAuthorityAD() {
+        String expectedArn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-ca-ad";
+        CreateCertificateAuthorityResponse mockResponse = CreateCertificateAuthorityResponse.builder()
+                .certificateAuthorityArn(expectedArn)
+                .build();
+        
+        GetCertificateAuthorityCsrResponse mockCsrResponse = GetCertificateAuthorityCsrResponse.builder()
+                .csr("-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE REQUEST-----")
+                .build();
+        
+        IssueCertificateResponse mockIssueResponse = IssueCertificateResponse.builder()
+                .certificateArn("arn:aws:acm-pca:us-east-1:123456789012:certificate/test-cert")
+                .build();
+        
+        GetCertificateResponse mockGetCertResponse = GetCertificateResponse.builder()
+                .certificate("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE-----")
+                .build();
+        
+        when(mockClient.createCertificateAuthority(any(CreateCertificateAuthorityRequest.class)))
+                .thenReturn(mockResponse);
+        when(mockClient.getCertificateAuthorityCsr(any(GetCertificateAuthorityCsrRequest.class)))
+                .thenReturn(mockCsrResponse);
+        when(mockClient.issueCertificate(any(IssueCertificateRequest.class)))
+                .thenReturn(mockIssueResponse);
+        when(mockClient.getCertificate(any(GetCertificateRequest.class)))
+                .thenReturn(mockGetCertResponse);
+
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> CreatePrivateCertificateAuthorityAD.main(new String[]{"us-east-1"}));
+            verify(mockClient).createCertificateAuthority(any(CreateCertificateAuthorityRequest.class));
+            verify(mockClient).getCertificateAuthorityCsr(any(GetCertificateAuthorityCsrRequest.class));
+            verify(mockClient).issueCertificate(any(IssueCertificateRequest.class));
+            verify(mockClient).getCertificate(any(GetCertificateRequest.class));
+            verify(mockClient).importCertificateAuthorityCertificate(any(ImportCertificateAuthorityCertificateRequest.class));
+            assertTrue(outputStream.toString().contains(expectedArn), "Should output the certificate authority ARN");
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> CreatePrivateCertificateAuthorityAD.main(new String[]{}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 24 passed");
+    }
+
+    @Test
+    @Order(25)
+    public void testRootCAActivation() {
+        String expectedArn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-root-ca";
+        CreateCertificateAuthorityResponse mockCreateResponse = CreateCertificateAuthorityResponse.builder()
+                .certificateAuthorityArn(expectedArn)
+                .build();
+        
+        GetCertificateAuthorityCsrResponse mockCsrResponse = GetCertificateAuthorityCsrResponse.builder()
+                .csr("-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE REQUEST-----")
+                .build();
+        
+        IssueCertificateResponse mockIssueResponse = IssueCertificateResponse.builder()
+                .certificateArn("arn:aws:acm-pca:us-east-1:123456789012:certificate/test-cert")
+                .build();
+        
+        GetCertificateResponse mockGetCertResponse = GetCertificateResponse.builder()
+                .certificate("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE-----")
+                .build();
+        
+        when(mockClient.createCertificateAuthority(any(CreateCertificateAuthorityRequest.class)))
+                .thenReturn(mockCreateResponse);
+        when(mockClient.getCertificateAuthorityCsr(any(GetCertificateAuthorityCsrRequest.class)))
+                .thenReturn(mockCsrResponse);
+        when(mockClient.issueCertificate(any(IssueCertificateRequest.class)))
+                .thenReturn(mockIssueResponse);
+        when(mockClient.getCertificate(any(GetCertificateRequest.class)))
+                .thenReturn(mockGetCertResponse);
+
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> RootCAActivation.main(new String[]{"us-east-1", "test-bucket"}));
+            verify(mockClient).createCertificateAuthority(any(CreateCertificateAuthorityRequest.class));
+            verify(mockClient).getCertificateAuthorityCsr(any(GetCertificateAuthorityCsrRequest.class));
+            verify(mockClient).issueCertificate(any(IssueCertificateRequest.class));
+            verify(mockClient).getCertificate(any(GetCertificateRequest.class));
+            verify(mockClient).importCertificateAuthorityCertificate(any(ImportCertificateAuthorityCertificateRequest.class));
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> RootCAActivation.main(new String[]{}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 25 passed");
+    }
+
+    @Test
+    @Order(26)
+    public void testSubordinateCAActivation() {
+        String rootCaArn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-root-ca";
+        String subCaArn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/test-sub-ca";
+        
+        GetCertificateAuthorityCertificateResponse mockRootCertResponse = GetCertificateAuthorityCertificateResponse.builder()
+                .certificate("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE-----")
+                .build();
+        
+        CreateCertificateAuthorityResponse mockCreateResponse = CreateCertificateAuthorityResponse.builder()
+                .certificateAuthorityArn(subCaArn)
+                .build();
+        
+        GetCertificateAuthorityCsrResponse mockCsrResponse = GetCertificateAuthorityCsrResponse.builder()
+                .csr("-----BEGIN CERTIFICATE REQUEST-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE REQUEST-----")
+                .build();
+        
+        IssueCertificateResponse mockIssueResponse = IssueCertificateResponse.builder()
+                .certificateArn("arn:aws:acm-pca:us-east-1:123456789012:certificate/test-sub-cert")
+                .build();
+        
+        GetCertificateResponse mockGetCertResponse = GetCertificateResponse.builder()
+                .certificate("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE-----")
+                .certificateChain("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAK...\n-----END CERTIFICATE-----")
+                .build();
+        
+        when(mockClient.getCertificateAuthorityCertificate(any(GetCertificateAuthorityCertificateRequest.class)))
+                .thenReturn(mockRootCertResponse);
+        when(mockClient.createCertificateAuthority(any(CreateCertificateAuthorityRequest.class)))
+                .thenReturn(mockCreateResponse);
+        when(mockClient.getCertificateAuthorityCsr(any(GetCertificateAuthorityCsrRequest.class)))
+                .thenReturn(mockCsrResponse);
+        when(mockClient.issueCertificate(any(IssueCertificateRequest.class)))
+                .thenReturn(mockIssueResponse);
+        when(mockClient.getCertificate(any(GetCertificateRequest.class)))
+                .thenReturn(mockGetCertResponse);
+
+        try (MockedStatic<AcmPcaClient> mockedStatic = mockStatic(AcmPcaClient.class)) {
+            setupMockClient(mockedStatic);
+            
+            assertDoesNotThrow(() -> SubordinateCAActivation.main(new String[]{
+                "us-east-1", 
+                rootCaArn,
+                "test-bucket"
+            }));
+            verify(mockClient).getCertificateAuthorityCertificate(any(GetCertificateAuthorityCertificateRequest.class));
+            verify(mockClient).createCertificateAuthority(any(CreateCertificateAuthorityRequest.class));
+            verify(mockClient).getCertificateAuthorityCsr(any(GetCertificateAuthorityCsrRequest.class));
+            verify(mockClient).issueCertificate(any(IssueCertificateRequest.class));
+            verify(mockClient).getCertificate(any(GetCertificateRequest.class));
+            verify(mockClient).importCertificateAuthorityCertificate(any(ImportCertificateAuthorityCertificateRequest.class));
+            
+            resetStreamsAndMocks();
+            
+            assertDoesNotThrow(() -> SubordinateCAActivation.main(new String[]{}));
+            assertTrue(outputStream.toString().contains("Usage:"), "Should show usage message");
+            verifyNoInteractions(mockClient);
+        }
+        originalOut.println("Test 26 passed");
     }
 
     private void setupMockClient(MockedStatic<AcmPcaClient> mockedStatic) {


### PR DESCRIPTION
<!--
Thank you for making a submission to the *aws-doc-sdk-examples* repository. Briefly tell us what you intend to change with this PR.
Format the PR _title_ like this: <Language>: <what you did in> <AWS service>
In the PR _body_, you can describe your changes in more detail. If the title is descriptive enough, however, you can delete the body.
-->

```
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------------------< org.example:acmpca >-------------------------
[INFO] Building acmpca 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ acmpca ---
[INFO] skip non existing resourceDirectory /workplace/prac-aws-doc-sdk-examples/javav2/example_code/acmpca/src/main/resources
[INFO] 
[INFO] --- compiler:3.11.0:compile (default-compile) @ acmpca ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ acmpca ---
[INFO] skip non existing resourceDirectory /workplace/prac-aws-doc-sdk-examples/javav2/example_code/acmpca/src/test/resources
[INFO] 
[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ acmpca ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ acmpca ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running PCATests
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
Test 1 passed
Test 2 passed
Test 3 passed
Test 4 passed
Test 5 passed
Test 6 passed
Test 7 passed
Test 8 passed
Test 9 passed
Test 10 passed
Test 11 passed
Test 12 passed
Test 13 passed
Test 14 passed
Test 15 passed
Test 16 passed
Test 17 passed
Test 18 passed
Test 19 passed
Test 20 passed
Test 21 passed
Test 22 passed
Test 23 passed
Test 24 passed
Test 25 passed
Test 26 passed
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.076 s -- in PCATests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.181 s
[INFO] Finished at: 2025-07-31T21:38:46Z
[INFO] ------------------------------------------------------------------------
```
---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
